### PR TITLE
feat(inscription): ajout du club d'appartenance lors de l'inscription…

### DIFF
--- a/src/main/java/org/santalina/diving/domain/SlotDiver.java
+++ b/src/main/java/org/santalina/diving/domain/SlotDiver.java
@@ -48,6 +48,9 @@ public class SlotDiver extends PanacheEntityBase {
     @Column(columnDefinition = "TEXT")
     public String comment;
 
+    @Column
+    public String club;
+
     @Column(name = "added_at", nullable = false)
     public LocalDateTime addedAt = LocalDateTime.now();
 

--- a/src/main/java/org/santalina/diving/domain/WaitingListEntry.java
+++ b/src/main/java/org/santalina/diving/domain/WaitingListEntry.java
@@ -55,6 +55,10 @@ public class WaitingListEntry extends PanacheEntityBase {
     @Column(name = "medical_cert_date")
     public LocalDate medicalCertDate;
 
+    /** Club d'appartenance du plongeur (optionnel). */
+    @Column
+    public String club;
+
     /** Atteste que le plongeur a vérifié la validité de sa licence FFESSM. */
     @Column(name = "license_confirmed", nullable = false)
     public boolean licenseConfirmed = false;

--- a/src/main/java/org/santalina/diving/dto/BackupDto.java
+++ b/src/main/java/org/santalina/diving/dto/BackupDto.java
@@ -77,7 +77,8 @@ public class BackupDto {
             Long palanqueeId,
             int palanqueePosition,
             LocalDate medicalCertDate,
-            String comment
+            String comment,
+            String club
     ) {}
 
     public record PalanqueeEntry(
@@ -102,7 +103,8 @@ public class BackupDto {
             String comment,
             LocalDateTime registeredAt,
             LocalDate medicalCertDate,
-            boolean licenseConfirmed
+            boolean licenseConfirmed,
+            String club
     ) {}
 
     /** Réponse d'un import */

--- a/src/main/java/org/santalina/diving/dto/SlotDiverDto.java
+++ b/src/main/java/org/santalina/diving/dto/SlotDiverDto.java
@@ -16,7 +16,8 @@ public class SlotDiverDto {
             String phone,
             boolean isDirector,
             String aptitudes,
-            String licenseNumber
+            String licenseNumber,
+            String club
     ) {}
 
     public record SlotDiverResponse(
@@ -31,7 +32,8 @@ public class SlotDiverDto {
             String licenseNumber,
             Long userId,
             LocalDate medicalCertDate,
-            String comment
+            String comment,
+            String club
     ) {
         public static SlotDiverResponse from(SlotDiver d) {
             String licenseNumber = d.licenseNumber;
@@ -45,7 +47,7 @@ public class SlotDiverDto {
             }
             return new SlotDiverResponse(d.id, d.firstName, d.lastName, d.level,
                     d.email, d.phone, d.isDirector, d.aptitudes, licenseNumber, userId,
-                    d.medicalCertDate, d.comment);
+                    d.medicalCertDate, d.comment, d.club);
         }
     }
 }

--- a/src/main/java/org/santalina/diving/dto/WaitingListDto.java
+++ b/src/main/java/org/santalina/diving/dto/WaitingListDto.java
@@ -45,7 +45,8 @@ public class WaitingListDto {
             String preparedLevel,
             String comment,
             LocalDate medicalCertDate,
-            Boolean licenseConfirmed
+            Boolean licenseConfirmed,
+            String club
     ) {}
 
     /**
@@ -64,7 +65,8 @@ public class WaitingListDto {
             String comment,
             LocalDate medicalCertDate,
             boolean licenseConfirmed,
-            @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime registeredAt
+            @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime registeredAt,
+            String club
     ) {
         public static WaitingListResponse from(WaitingListEntry e) {
             return new WaitingListResponse(
@@ -80,7 +82,8 @@ public class WaitingListDto {
                     e.comment,
                     e.medicalCertDate,
                     e.licenseConfirmed,
-                    e.registeredAt
+                    e.registeredAt,
+                    e.club
             );
         }
     }

--- a/src/main/java/org/santalina/diving/resource/SlotDiverResource.java
+++ b/src/main/java/org/santalina/diving/resource/SlotDiverResource.java
@@ -179,6 +179,7 @@ public class SlotDiverResource {
         diver.isDirector    = request.isDirector();
         diver.aptitudes     = request.aptitudes();
         diver.licenseNumber = request.licenseNumber();
+        diver.club          = request.club();
         diver.persist();
 
         return SlotDiverResponse.from(diver);

--- a/src/main/java/org/santalina/diving/resource/WaitingListResource.java
+++ b/src/main/java/org/santalina/diving/resource/WaitingListResource.java
@@ -118,6 +118,7 @@ public class WaitingListResource {
         entry.comment       = request.comment();
         entry.medicalCertDate  = request.medicalCertDate();
         entry.licenseConfirmed = Boolean.TRUE.equals(request.licenseConfirmed());
+        entry.club             = request.club();
         entry.persist();
 
         mailer.sendWaitingListConfirmation(entry, slot);
@@ -206,6 +207,7 @@ public class WaitingListResource {
         diver.aptitudes     = null;  // preparedLevel est informatif uniquement, pas pré-rempli dans les aptitudes
         diver.medicalCertDate = entry.medicalCertDate;
         diver.comment        = entry.comment;
+        diver.club           = entry.club;
         diver.persist();
 
         // Planifier l'envoi du mail de validation avec le délai de grâce (15 min)

--- a/src/main/java/org/santalina/diving/service/BackupService.java
+++ b/src/main/java/org/santalina/diving/service/BackupService.java
@@ -216,6 +216,7 @@ public class BackupService {
                 diver.licenseNumber = d.licenseNumber();
                 diver.medicalCertDate = d.medicalCertDate();
                 diver.comment       = d.comment();
+                diver.club          = d.club();
                 diver.addedAt       = LocalDateTime.now();
                 diver.persist();
                 diverCount++;
@@ -298,6 +299,7 @@ public class BackupService {
                 entry.registeredAt    = we.registeredAt() != null ? we.registeredAt() : LocalDateTime.now();
                 entry.medicalCertDate = we.medicalCertDate();
                 entry.licenseConfirmed = we.licenseConfirmed();
+                entry.club          = we.club();
                 entry.persist();
                 waitingListCount++;
             }
@@ -337,7 +339,7 @@ public class BackupService {
                 d.firstName, d.lastName, d.level, d.email, d.phone,
                 d.isDirector, d.aptitudes, d.licenseNumber,
                 d.palanquee != null ? d.palanquee.id : null, d.palanqueePosition,
-                d.medicalCertDate, d.comment);
+                d.medicalCertDate, d.comment, d.club);
     }
 
     private PalanqueeEntry toPalanqueeEntry(Palanquee p) {
@@ -349,7 +351,7 @@ public class BackupService {
         return new WaitingListBackupEntry(e.id, e.slot != null ? e.slot.id : null,
                 e.firstName, e.lastName, e.email, e.level,
                 e.numberOfDives, e.lastDiveDate, e.preparedLevel, e.comment, e.registeredAt,
-                e.medicalCertDate, e.licenseConfirmed);
+                e.medicalCertDate, e.licenseConfirmed, e.club);
     }
 }
 

--- a/src/main/resources/db/migration/V31__waiting_list_club.sql
+++ b/src/main/resources/db/migration/V31__waiting_list_club.sql
@@ -1,0 +1,3 @@
+-- V31 : Club d'appartenance du plongeur dans la liste d'attente
+-- Permet au plongeur de préciser son club lors de l'inscription libre
+ALTER TABLE waiting_list_entries ADD COLUMN club VARCHAR(255);

--- a/src/main/resources/db/migration/V32__slot_diver_club.sql
+++ b/src/main/resources/db/migration/V32__slot_diver_club.sql
@@ -1,0 +1,3 @@
+-- V32 : Club d'appartenance du plongeur dans les inscrits d'un créneau
+-- Transféré depuis la liste d'attente lors de la validation, ou saisi manuellement par le DP
+ALTER TABLE slot_divers ADD COLUMN club VARCHAR(255);

--- a/src/main/webui/src/components/SelfRegistrationModal.tsx
+++ b/src/main/webui/src/components/SelfRegistrationModal.tsx
@@ -10,9 +10,10 @@ interface Props {
   slot: DiveSlot;
   onClose: () => void;
   onSuccess: (newEmail?: string) => void;
+  clubs?: string[];
 }
 
-export function SelfRegistrationModal({ slot, onClose, onSuccess }: Props) {
+export function SelfRegistrationModal({ slot, onClose, onSuccess, clubs = [] }: Props) {
   const storedUser = authService.getStoredUser();
   const isDP = storedUser?.role === 'DIVE_DIRECTOR';
   const availableLevels: readonly string[] = isDP ? DP_LEVELS : DIVER_LEVELS;
@@ -21,6 +22,7 @@ export function SelfRegistrationModal({ slot, onClose, onSuccess }: Props) {
   const [email, setEmail]               = useState(originalEmail);
   const [emailConfirm, setEmailConfirm] = useState(originalEmail);
   const [level, setLevel]               = useState('');
+  const [club, setClub]                 = useState('');
   const [preparedLevel, setPreparedLevel] = useState('Aucun');
   const [comment, setComment]           = useState('');
   const [medicalCertDate, setMedicalCertDate] = useState('');
@@ -90,6 +92,7 @@ export function SelfRegistrationModal({ slot, onClose, onSuccess }: Props) {
         comment: comment.trim() || undefined,
         medicalCertDate,
         licenseConfirmed,
+        club: club || undefined,
       });
       onSuccess(emailChanged ? trimmedEmail : undefined);
     } catch (err) {
@@ -175,6 +178,18 @@ export function SelfRegistrationModal({ slot, onClose, onSuccess }: Props) {
               </select>
             </div>
           </div>
+
+          {clubs.length > 0 && (
+            <div className="form-group" style={{ marginTop: 12 }}>
+              <label>Votre club d'appartenance</label>
+              <select value={club} onChange={e => setClub(e.target.value)}>
+                <option value="">— Aucun / Non affilié —</option>
+                {clubs.map(c => (
+                  <option key={c} value={c}>{c}</option>
+                ))}
+              </select>
+            </div>
+          )}
 
           <div className="form-group" style={{ marginTop: 12 }}>
             <label>Message pour le DP (optionnel)</label>

--- a/src/main/webui/src/components/SlotBlock.tsx
+++ b/src/main/webui/src/components/SlotBlock.tsx
@@ -1131,6 +1131,7 @@ export function SlotBlock({
       {showSelfRegModal && (
         <SelfRegistrationModal
           slot={slot}
+          clubs={config?.clubs ?? []}
           onClose={() => setShowSelfRegModal(false)}
           onSuccess={(newEmail?: string) => {
             setShowSelfRegModal(false);

--- a/src/main/webui/src/pages/HelpPage.tsx
+++ b/src/main/webui/src/pages/HelpPage.tsx
@@ -241,6 +241,7 @@ export function HelpPage() {
             <li><strong>Niveau</strong> — niveau de certification.</li>
             <li><strong>Email</strong> — adresse e-mail si renseignée.</li>
             <li><strong>Directeur de plongée</strong> — « Oui » si le plongeur est le directeur du créneau.</li>
+            <li><strong>Club</strong> — club d'appartenance fourni lors de l'inscription libre (vide si le plongeur a été ajouté manuellement par un DP).</li>
             <li><strong>Date certificat médical</strong> — date fournie lors de l'inscription libre (vide si le plongeur a été ajouté manuellement par un DP).</li>
             <li><strong>Commentaire</strong> — commentaire laissé par le plongeur lors de l'inscription libre (vide si ajout manuel).</li>
           </ul>
@@ -319,6 +320,7 @@ export function HelpPage() {
                 <li><strong>Prénom / Nom</strong> — champs obligatoires.</li>
                 <li><strong>E-mail</strong> (double saisie obligatoire pour éviter les erreurs)</li>
                 <li><strong>Niveau de certification</strong> — sélectionner parmi : N1, N2, N3, N4, N5, E2, E3, E4, PE12, PE40, PE60, MF1, MF2.</li>
+                <li><strong>Club d'appartenance</strong> — optionnel, sélectionner votre club dans la liste configurée par l'administrateur. Affiché dans la liste d'attente pour aider le DP à identifier les plongeurs.</li>
                 <li><strong>Nombre de plongées effectuées</strong> — champ obligatoire.</li>
                 <li><strong>Date de la dernière plongée</strong> — champ obligatoire.</li>
                 <li><strong>Niveau en préparation</strong> — optionnel (vaste liste disponible).</li>
@@ -369,13 +371,13 @@ export function HelpPage() {
           <ol>
             <li>Les inscriptions apparaissent dans l'ordre d'arrivée (#1 = le premier inscrit).</li>
             <li>
-              Pour chaque entrée, vous voyez : nom, niveau, e-mail, nombre de plongées, date de la dernière plongée, niveau en préparation et commentaire éventuel.
+              Pour chaque entrée, vous voyez : nom, niveau, club d'appartenance (si renseigné), e-mail, nombre de plongées, date de la dernière plongée, niveau en préparation et commentaire éventuel.
             </li>
             <li>
               Cliquez sur <strong>✓ Valider</strong> pour accepter la demande :
               le plongeur est transféré dans la liste des inscrits et reçoit un e-mail de confirmation après un délai de 15 minutes
               (pour laisser le temps au DP de réorganiser les palanquées avant que le plongeur soit notifié).
-              La <strong>date du certificat médical</strong> et le <strong>commentaire</strong> sont conservés et apparaîtront dans l'export CSV.
+              La <strong>date du certificat médical</strong>, le <strong>commentaire</strong> et le <strong>club d'appartenance</strong> sont conservés et apparaîtront dans la liste des inscrits.
             </li>
             <li>
               Cliquez sur <strong>✕</strong> pour refuser / supprimer la demande ; 
@@ -590,7 +592,7 @@ export function HelpPage() {
           <h4>Listes configurables</h4>
           <ul>
             <li><strong>Types de plongée</strong> — ex : Exploration, Formation, Apnée. Chaque entrée peut être personnalisée avec une couleur.</li>
-            <li><strong>Clubs</strong> — liste des clubs participants, associée à chaque créneau.</li>
+            <li><strong>Clubs</strong> — liste des clubs participants. Utilisée à deux endroits : associée à chaque <strong>créneau</strong> (club organisateur) et proposée aux plongeurs lors de leur <strong>inscription libre</strong> pour indiquer leur club d'appartenance.</li>
           </ul>
 
           <h4>Accès &amp; inscriptions</h4>
@@ -743,7 +745,7 @@ export function HelpPage() {
           { type: 'h4' as const, text: 'Contenu de la fiche' },
           { type: 'ul' as const, items: ['Cellule B4 — Date, club et infos DP : NOM Prénom - Niveau - N°Licence.', 'Colonnes A–C — Nom, prénom et niveau de chaque plongeur.', 'Colonne D — Aptitudes du plongeur (PE20, PA40, GP…) si renseignées dans l\'organisation des palanquées.', 'Si des palanquées sont organisées, chaque palanquée est dans un tableau séparé.'] },
           { type: 'h4' as const, text: 'Export CSV' },
-          { type: 'paragraph' as const, text: 'Un export CSV est également disponible depuis le panneau de détails (bouton Télécharger liste CSV). Il contient : Nom, Prénom, Niveau, Email, Directeur de plongée, Date certificat médical, Commentaire.' },
+          { type: 'paragraph' as const, text: 'Un export CSV est également disponible depuis le panneau de détails (bouton Télécharger liste CSV). Il contient : Nom, Prénom, Niveau, Email, Directeur de plongée, Club, Date certificat médical, Commentaire.' },
           { type: 'tip' as const, text: 'Pour que la licence du DP apparaisse, elle doit être saisie dans son profil ou dans le formulaire DP sur le créneau.' },
         ],
       },

--- a/src/main/webui/src/pages/PalanqueePage.tsx
+++ b/src/main/webui/src/pages/PalanqueePage.tsx
@@ -770,6 +770,11 @@ export function PalanqueePage({ slotId, onBack }: Props) {
                       <a href={`mailto:${entry.email}`} className="palanquee-wl-entry-email" title="Envoyer un e-mail">
                         ✉️ {entry.email}
                       </a>
+                      {entry.club && (
+                        <span className="palanquee-wl-chip" title="Club d'appartenance">
+                          🏊 {entry.club}
+                        </span>
+                      )}
                       {entry.numberOfDives !== undefined && (
                         <span className="palanquee-wl-chip" title="Nombre de plongées">
                           🤿 {entry.numberOfDives} plongée{entry.numberOfDives > 1 ? 's' : ''}

--- a/src/main/webui/src/types/index.ts
+++ b/src/main/webui/src/types/index.ts
@@ -73,6 +73,7 @@ export interface SlotDiver {
   userId?: number;
   medicalCertDate?: string;
   comment?: string;
+  club?: string;
 }
 
 export interface SlotDiverRequest {
@@ -84,6 +85,7 @@ export interface SlotDiverRequest {
   isDirector: boolean;
   aptitudes?: string;
   licenseNumber?: string;
+  club?: string;
 }
 
 export interface DiveSlot {
@@ -259,6 +261,7 @@ export interface WaitingListEntry {
   registeredAt: string;     // ISO datetime
   medicalCertDate?: string;  // YYYY-MM-DD
   licenseConfirmed?: boolean;
+  club?: string;
 }
 
 export interface WaitingListRequest {
@@ -273,6 +276,7 @@ export interface WaitingListRequest {
   comment?: string;
   medicalCertDate: string;   // YYYY-MM-DD
   licenseConfirmed: boolean;
+  club?: string;
 }
 
 export interface UpdateRegistrationRequest {

--- a/src/main/webui/src/utils/exportDiverList.ts
+++ b/src/main/webui/src/utils/exportDiverList.ts
@@ -14,7 +14,7 @@ export function exportDiverListCsv(slot: DiveSlot, divers: SlotDiver[]): void {
   const filename = `${slot.slotDate ?? 'creneau'}-${slot.startTime?.replace(':', '-') ?? ''}-liste-plongeurs.csv`;
 
   // En-tête CSV
-  const lines: string[] = ['\uFEFF' + 'Nom;Prénom;Niveau;Email;Directeur de plongée;Date certificat médical;Commentaire'];
+  const lines: string[] = ['\uFEFF' + 'Nom;Prénom;Niveau;Email;Directeur de plongée;Club;Date certificat médical;Commentaire'];
 
   // Tri : DP en premier, puis alphabétique
   const sorted = [...divers].sort(
@@ -28,6 +28,7 @@ export function exportDiverListCsv(slot: DiveSlot, divers: SlotDiver[]): void {
       d.level ?? '',
       d.email ?? '',
       d.isDirector ? 'Oui' : '',
+      d.club ?? '',
       d.medicalCertDate ? fmtDate(d.medicalCertDate) : '',
       d.comment ?? '',
     ].map(f => `"${f.replace(/"/g, '""')}"`);

--- a/src/test/java/org/santalina/diving/integration/BackupResourceIT.java
+++ b/src/test/java/org/santalina/diving/integration/BackupResourceIT.java
@@ -227,7 +227,8 @@ class BackupResourceIT {
                             "comment": "Test commentaire",
                             "registeredAt": "2099-01-01T00:00:00",
                             "medicalCertDate": "2099-01-01",
-                            "licenseConfirmed": true
+                            "licenseConfirmed": true,
+                            "club": "Club Santalina"
                         }
                     ]
                 }

--- a/src/test/java/org/santalina/diving/integration/WaitingListResourceIT.java
+++ b/src/test/java/org/santalina/diving/integration/WaitingListResourceIT.java
@@ -301,6 +301,50 @@ class WaitingListResourceIT {
     }
 
     @Test
+    @TestSecurity(user = "diver@test.com", roles = {"DIVER"})
+    void register_shouldReturn201_withClub_andClubPersistedInResponse() {
+        DiveSlot slot = createSlot(true);
+        try {
+            given()
+                .contentType(ContentType.JSON)
+                .body("""
+                    {"firstName":"Bob","lastName":"DUPONT",
+                     "email":"bob_club@test.com","emailConfirm":"bob_club@test.com",
+                     "level":"N2","numberOfDives":20,
+                     "lastDiveDate":"2025-03-15",
+                     "medicalCertDate":"2099-07-01",
+                     "licenseConfirmed":true,
+                     "club":"Club Santalina"}
+                    """)
+                .when().post("/api/slots/{slotId}/waiting-list", slot.id)
+                .then()
+                .statusCode(201)
+                .body("club", equalTo("Club Santalina"));
+        } finally {
+            cleanup(slot.id);
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "admin@test.com", roles = {"ADMIN"})
+    void approve_shouldTransferClubToSlotDiver() {
+        DiveSlot slot = createSlot(true);
+        try {
+            WaitingListEntry entry = createEntryWithClub(slot.id, "Club Santalina");
+
+            given()
+                .contentType(ContentType.JSON)
+                .when().post("/api/slots/{slotId}/waiting-list/{entryId}/approve",
+                        slot.id, entry.id)
+                .then()
+                .statusCode(200)
+                .body("club", equalTo("Club Santalina"));
+        } finally {
+            cleanup(slot.id);
+        }
+    }
+
+    @Test
     @TestSecurity(user = "admin@test.com", roles = {"ADMIN"})
     void approve_shouldReturn200_andTransferToDivers() {
         DiveSlot slot = createSlot(true);
@@ -354,6 +398,24 @@ class WaitingListResourceIT {
         } finally {
             cleanup(slot.id);
         }
+    }
+
+    @Transactional
+    WaitingListEntry createEntryWithClub(Long slotId, String club) {
+        DiveSlot slot = DiveSlot.findById(slotId);
+        WaitingListEntry entry = new WaitingListEntry();
+        entry.slot          = slot;
+        entry.firstName     = "Alice";
+        entry.lastName      = "MARTIN";
+        entry.email         = "alice_club_" + System.nanoTime() + "@test.com";
+        entry.level         = "N2";
+        entry.numberOfDives = 30;
+        entry.lastDiveDate  = LocalDate.of(2025, 1, 15);
+        entry.medicalCertDate = LocalDate.of(2025, 3, 1);
+        entry.comment       = "Je veux travailler la remontée lente";
+        entry.club          = club;
+        entry.persist();
+        return entry;
     }
 
     // ── helpers secondaires ────────────────────────────────────────────────────


### PR DESCRIPTION
… libre

Migrations BDD :
- V31 : ajout de la colonne `club` sur `waiting_list_entries`
- V32 : ajout de la colonne `club` sur `slot_divers`

Backend :
- Domaine : champ `club` ajouté sur WaitingListEntry et SlotDiver
- DTO : WaitingListRequest/Response, SlotDiverRequest/Response et BackupDto (DiverEntry + WaitingListBackupEntry) mis à jour
- WaitingListResource : persistence du club à l'inscription ; transfert du club vers slot_divers lors de la validation (approve)
- SlotDiverResource : prise en compte du club lors de l'ajout/ modification manuelle d'un plongeur
- BackupService : export et import du champ club pour les plongeurs et la liste d'attente

Frontend :
- SelfRegistrationModal : sélecteur de club (liste issue de la config admin), affiché uniquement si des clubs sont configurés
- SlotBlock : transmission de `config.clubs` au modal d'inscription
- PalanqueePage : badge club affiché dans les entrées de liste d'attente
- exportDiverList : colonne « Club » ajoutée à l'export CSV

Tests :
- WaitingListResourceIT : 2 nouveaux tests (club persisté à l'inscription, club transféré à la validation) + helper
- BackupResourceIT : champ club inclus dans le payload d'import

Documentation :
- HelpPage : sections inscription libre, export CSV et configuration admin mises à jour