### PR TITLE
feat: création de créneau pour le compte d'un autre DP (admin) + fix …

### DIFF
--- a/src/main/java/org/santalina/diving/dto/SlotDto.java
+++ b/src/main/java/org/santalina/diving/dto/SlotDto.java
@@ -26,7 +26,9 @@ public class SlotDto {
             // Champs récurrence
             Boolean recurring,
             List<Integer> recurringDays,   // 1=Lun … 7=Dim (ISO DayOfWeek)
-            LocalDate recurringUntil
+            LocalDate recurringUntil,
+            // Création pour le compte d'un autre utilisateur (ADMIN uniquement)
+            Long createdByUserId
     ) {}
 
     public record UpdateDiverCountRequest(

--- a/src/main/java/org/santalina/diving/resource/SlotResource.java
+++ b/src/main/java/org/santalina/diving/resource/SlotResource.java
@@ -5,6 +5,7 @@ import org.santalina.diving.domain.UserRole;
 import org.santalina.diving.dto.SlotDto.*;
 import org.santalina.diving.dto.WaitingListDto.UpdateRegistrationRequest;
 import org.santalina.diving.service.SlotService;
+import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.annotation.security.PermitAll;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
@@ -12,7 +13,6 @@ import jakarta.validation.Valid;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import java.time.LocalDate;
@@ -28,7 +28,7 @@ public class SlotResource {
     SlotService slotService;
 
     @Inject
-    JsonWebToken jwt;
+    SecurityIdentity identity;
 
     @GET
     @PermitAll
@@ -64,9 +64,17 @@ public class SlotResource {
     @POST
     @RolesAllowed({"ADMIN", "DIVE_DIRECTOR"})
     public Response create(@Valid SlotRequest request) {
-        User currentUser = User.findByEmail(jwt.getName());
+        User currentUser = User.findByEmail(identity.getPrincipal().getName());
         if (currentUser == null) throw new NotAuthorizedException("Utilisateur non trouvé");
-        BatchSlotResponse batch = slotService.createSlots(request, currentUser);
+        User creatorUser = currentUser;
+        if (request.createdByUserId() != null && currentUser.roles.contains(UserRole.ADMIN)) {
+            User target = User.findById(request.createdByUserId());
+            if (target == null) throw new NotFoundException("Directeur de plongée cible non trouvé");
+            if (!target.roles.contains(UserRole.DIVE_DIRECTOR))
+                throw new BadRequestException("L'utilisateur cible n'est pas directeur de plongée");
+            creatorUser = target;
+        }
+        BatchSlotResponse batch = slotService.createSlots(request, creatorUser);
         return Response.status(201).entity(batch).build();
     }
 
@@ -74,7 +82,7 @@ public class SlotResource {
     @Path("/{id}")
     @RolesAllowed({"ADMIN", "DIVE_DIRECTOR"})
     public Response delete(@PathParam("id") Long id) {
-        User currentUser = User.findByEmail(jwt.getName());
+        User currentUser = User.findByEmail(identity.getPrincipal().getName());
         if (currentUser == null) throw new NotAuthorizedException("Utilisateur non trouvé");
         slotService.deleteSlot(id, currentUser);
         return Response.noContent().build();
@@ -85,7 +93,7 @@ public class SlotResource {
     @RolesAllowed({"ADMIN", "DIVE_DIRECTOR"})
     public SlotResponse updateDiverCount(@PathParam("id") Long id,
                                          @Valid UpdateDiverCountRequest request) {
-        User currentUser = User.findByEmail(jwt.getName());
+        User currentUser = User.findByEmail(identity.getPrincipal().getName());
         if (currentUser == null) throw new NotAuthorizedException("Utilisateur non trouvé");
         return slotService.updateDiverCount(id, request.diverCount(), currentUser);
     }
@@ -95,7 +103,7 @@ public class SlotResource {
     @RolesAllowed({"ADMIN", "DIVE_DIRECTOR"})
     public SlotResponse updateSlotInfo(@PathParam("id") Long id,
                                        UpdateSlotInfoRequest request) {
-        User currentUser = User.findByEmail(jwt.getName());
+        User currentUser = User.findByEmail(identity.getPrincipal().getName());
         if (currentUser == null) throw new NotAuthorizedException("Utilisateur non trouvé");
         return slotService.updateSlotInfo(id, request, currentUser);
     }
@@ -105,7 +113,7 @@ public class SlotResource {
     @RolesAllowed({"ADMIN", "DIVE_DIRECTOR"})
     public SlotResponse updateRegistration(@PathParam("id") Long id,
                                            UpdateRegistrationRequest request) {
-        User currentUser = User.findByEmail(jwt.getName());
+        User currentUser = User.findByEmail(identity.getPrincipal().getName());
         if (currentUser == null) throw new NotAuthorizedException("Utilisateur non trouvé");
         return slotService.updateRegistration(id, request, currentUser);
     }

--- a/src/main/java/org/santalina/diving/resource/UserResource.java
+++ b/src/main/java/org/santalina/diving/resource/UserResource.java
@@ -64,6 +64,13 @@ public class UserResource {
         return userService.searchUsers(q);
     }
 
+    @GET
+    @Path("/dive-directors")
+    @RolesAllowed("ADMIN")
+    public List<UserSearchResult> getDiveDirectors() {
+        return userService.getDiveDirectors();
+    }
+
     @POST
     @RolesAllowed("ADMIN")
     public Response createUser(@Valid CreateUserRequest request) {

--- a/src/main/java/org/santalina/diving/service/UserService.java
+++ b/src/main/java/org/santalina/diving/service/UserService.java
@@ -87,6 +87,16 @@ public class UserService {
                 .toList();
     }
 
+    public List<UserSearchResult> getDiveDirectors() {
+        return User.<User>listAll()
+                .stream()
+                .filter(u -> u.activated && u.roles.contains(UserRole.DIVE_DIRECTOR))
+                .sorted(Comparator.comparing((User u) -> u.lastName)
+                                  .thenComparing(u -> u.firstName))
+                .map(UserSearchResult::from)
+                .toList();
+    }
+
     /** Supprime les diacritiques (accents) d'une chaîne */
     private static String stripAccents(String s) {
         if (s == null) return "";

--- a/src/main/webui/src/components/SlotForm.tsx
+++ b/src/main/webui/src/components/SlotForm.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
-import type { AppConfig, SlotRequest } from '../types';
+import { useEffect, useState } from 'react';
+import type { AppConfig, SlotRequest, UserSearchResult } from '../types';
 import { slotService } from '../services/slotService';
+import { adminService } from '../services/adminService';
 
 interface Props {
   date: string;
@@ -9,6 +10,8 @@ interface Props {
   onCancel: () => void;
   /** Heure de début pré-remplie (ex: issu d'un clic sur la grille) */
   initialStartTime?: string;
+  /** Indique si l'utilisateur courant est ADMIN (affiche le sélecteur de DP) */
+  isAdmin?: boolean;
 }
 
 function timeOptions(resolutionMinutes: number): string[] {
@@ -44,7 +47,7 @@ function addMonths(dateStr: string, months: number): string {
   return d.toISOString().slice(0, 10);
 }
 
-export function SlotForm({ date, config, onCreated, onCancel, initialStartTime }: Props) {
+export function SlotForm({ date, config, onCreated, onCancel, initialStartTime, isAdmin }: Props) {
   const safeConfig = {
     maxDivers: config?.maxDivers > 0 ? config.maxDivers : 25,
     slotResolutionMinutes: config?.slotResolutionMinutes > 0 ? config.slotResolutionMinutes : 15,
@@ -85,6 +88,16 @@ export function SlotForm({ date, config, onCreated, onCancel, initialStartTime }
   const [recurring, setRecurring]         = useState(false);
   const [recurringDays, setRecurringDays] = useState<number[]>([]);
   const [recurringUntil, setRecurringUntil] = useState(() => addMonths(date, 1));
+
+  // Création pour le compte d'un autre DP (ADMIN uniquement)
+  const [diveDirectors, setDiveDirectors]     = useState<UserSearchResult[]>([]);
+  const [createdByUserId, setCreatedByUserId] = useState<number | undefined>(undefined);
+
+  useEffect(() => {
+    if (isAdmin) {
+      adminService.getDiveDirectors().then(setDiveDirectors).catch(() => {});
+    }
+  }, [isAdmin]);
 
   const maxUntilDate = addMonths(slotDate, safeConfig.maxRecurringMonths);
 
@@ -146,6 +159,7 @@ export function SlotForm({ date, config, onCreated, onCancel, initialStartTime }
         recurring: recurring || undefined,
         recurringDays: recurring ? recurringDays : undefined,
         recurringUntil: recurring ? recurringUntil : undefined,
+        createdByUserId: isAdmin ? createdByUserId : undefined,
       };
       const result = await slotService.create(req);
       if (result.created > 1) {
@@ -241,6 +255,26 @@ export function SlotForm({ date, config, onCreated, onCancel, initialStartTime }
             <label>Notes (optionnel)</label>
             <textarea value={notes} onChange={e => setNotes(e.target.value)} rows={2} placeholder="Informations supplémentaires..." />
           </div>
+
+          {/* ── Créer pour le compte d'un DP (ADMIN uniquement) ── */}
+          {isAdmin && diveDirectors.length > 0 && (
+            <div className="form-group" style={{ borderTop: '1px solid #e5e7eb', paddingTop: 12, marginTop: 4 }}>
+              <label style={{ fontWeight: 600 }}>👤 Créer pour le compte de…</label>
+              <select
+                value={createdByUserId ?? ''}
+                onChange={e => setCreatedByUserId(e.target.value ? Number(e.target.value) : undefined)}
+                style={{ marginTop: 4 }}
+              >
+                <option value="">— Moi-même —</option>
+                {diveDirectors.map(dp => (
+                  <option key={dp.id} value={dp.id}>{dp.name}</option>
+                ))}
+              </select>
+              <p style={{ color: '#6b7280', fontSize: 12, marginTop: 4 }}>
+                Le créneau sera attribué au directeur de plongée sélectionné.
+              </p>
+            </div>
+          )}
 
           {/* ── Récurrence ── */}
           <div className="form-group" style={{ borderTop: '1px solid #e5e7eb', paddingTop: 12, marginTop: 4 }}>

--- a/src/main/webui/src/pages/CalendarPage.tsx
+++ b/src/main/webui/src/pages/CalendarPage.tsx
@@ -172,6 +172,7 @@ export function CalendarPage({ onNavigate, returnContext, onReturnConsumed }: {
             initialStartTime={formStartTime}
             onCreated={handleCreated}
             onCancel={closeForm}
+            isAdmin={user?.role === 'ADMIN'}
           />
         )}
       </main>

--- a/src/main/webui/src/pages/HelpPage.tsx
+++ b/src/main/webui/src/pages/HelpPage.tsx
@@ -78,6 +78,19 @@ export function HelpPage() {
             <li>Cliquez sur le bouton <strong>+</strong> qui apparaît en bas à droite de la cellule.</li>
           </ol>
 
+          {role === 'ADMIN' && (
+            <>
+              <h4>👤 Créer un créneau pour le compte d'un autre DP (administrateurs)</h4>
+              <p>En tant qu'administrateur, vous pouvez créer un créneau qui sera attribué à un autre directeur de plongée. Cela est utile pour pré-créer les créneaux de DP externes ou migrer des créneaux depuis une autre application.</p>
+              <ol>
+                <li>Ouvrez le formulaire de création de créneau.</li>
+                <li>En bas du formulaire, le champ <strong>Créer pour le compte de…</strong> affiche la liste des directeurs de plongée actifs.</li>
+                <li>Sélectionnez le DP pour qui créer le créneau. Laissez sur <em>Moi-même</em> pour créer un créneau en votre propre nom.</li>
+                <li>Validez normalement — le créneau apparaît avec le nom du DP sélectionné comme créateur.</li>
+              </ol>
+            </>
+          )}
+
           <div className="help-tip">💡 La date proposée dans le formulaire correspond à votre sélection dans le calendrier. Vous pouvez la modifier avant de valider pour créer un créneau à une autre date.</div>
         </>
       ),
@@ -703,6 +716,10 @@ export function HelpPage() {
           { type: 'ol' as const, items: ['Survolez (sur ordinateur uniquement) ou appuyez sur l\'en-tête d\'une colonne de jour dans la grille.', 'Cliquez sur le bouton + qui apparaît dans l\'en-tête.'] },
           { type: 'h4' as const, text: 'Depuis la vue Mois' },
           { type: 'ol' as const, items: ['Survolez (sur ordinateur uniquement) ou appuyez sur une cellule de jour.', 'Cliquez sur le bouton + qui apparaît en bas à droite de la cellule.'] },
+          ...(role === 'ADMIN' ? [
+            { type: 'h4' as const, text: '👤 Créer pour le compte d\'un autre DP (administrateurs)' },
+            { type: 'paragraph' as const, text: 'En bas du formulaire de création, le champ « Créer pour le compte de… » liste les directeurs de plongée actifs. Sélectionnez un DP pour lui attribuer le créneau. Utile pour migrer des créneaux depuis une autre application ou pré-créer les créneaux de DP externes.' },
+          ] : []),
           { type: 'tip' as const, text: 'La date proposée dans le formulaire correspond à votre sélection dans le calendrier. Vous pouvez la modifier avant de valider pour créer un créneau à une autre date.' },
         ],
       },

--- a/src/main/webui/src/pages/PalanqueePage.tsx
+++ b/src/main/webui/src/pages/PalanqueePage.tsx
@@ -775,7 +775,7 @@ export function PalanqueePage({ slotId, onBack }: Props) {
                           🏊 {entry.club}
                         </span>
                       )}
-                      {entry.numberOfDives !== undefined && (
+                      {entry.numberOfDives !== undefined && entry.numberOfDives > 0 && (
                         <span className="palanquee-wl-chip" title="Nombre de plongées">
                           🤿 {entry.numberOfDives} plongée{entry.numberOfDives > 1 ? 's' : ''}
                         </span>

--- a/src/main/webui/src/services/adminService.ts
+++ b/src/main/webui/src/services/adminService.ts
@@ -12,6 +12,11 @@ export const adminService = {
     return res.data;
   },
 
+  async getDiveDirectors(): Promise<UserSearchResult[]> {
+    const res = await api.get<UserSearchResult[]>('/users/dive-directors');
+    return res.data;
+  },
+
   async createUser(req: CreateUserRequest): Promise<User> {
     const res = await api.post<User>('/users', req);
     return res.data;

--- a/src/main/webui/src/types/index.ts
+++ b/src/main/webui/src/types/index.ts
@@ -124,6 +124,8 @@ export interface SlotRequest {
   recurring?: boolean;
   recurringDays?: number[];   // 1=Lun … 7=Dim (ISO)
   recurringUntil?: string;    // YYYY-MM-DD
+  // Création pour le compte d'un autre DP (ADMIN uniquement)
+  createdByUserId?: number;
 }
 
 export interface BatchSlotResponse {

--- a/src/test/java/org/santalina/diving/integration/SlotResourceIT.java
+++ b/src/test/java/org/santalina/diving/integration/SlotResourceIT.java
@@ -3,7 +3,11 @@ package org.santalina.diving.integration;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import io.restassured.http.ContentType;
+import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
+import org.santalina.diving.domain.DiveSlot;
+import org.santalina.diving.domain.User;
+import org.santalina.diving.domain.UserRole;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
@@ -13,6 +17,59 @@ import static org.hamcrest.Matchers.*;
  */
 @QuarkusTest
 class SlotResourceIT {
+
+    // ── fixtures ──────────────────────────────────────────────────────────────
+
+    @Transactional
+    long createDiveDirector(String email, String lastName) {
+        User dp = new User();
+        dp.email        = email;
+        dp.firstName    = "DP";
+        dp.lastName     = lastName;
+        dp.passwordHash = "x";
+        dp.activated    = true;
+        dp.role         = UserRole.DIVE_DIRECTOR;
+        dp.roles        = java.util.Set.of(UserRole.DIVE_DIRECTOR);
+        dp.persist();
+        return dp.id;
+    }
+
+    @Transactional
+    long createAdminUser(String email) {
+        User admin = new User();
+        admin.email        = email;
+        admin.firstName    = "Admin";
+        admin.lastName     = "TEST";
+        admin.passwordHash = "x";
+        admin.activated    = true;
+        admin.role         = UserRole.ADMIN;
+        admin.roles        = java.util.Set.of(UserRole.ADMIN);
+        admin.persist();
+        return admin.id;
+    }
+
+    @Transactional
+    long createDiver(String email) {
+        User diver = new User();
+        diver.email        = email;
+        diver.firstName    = "Diver";
+        diver.lastName     = "TEST";
+        diver.passwordHash = "x";
+        diver.activated    = true;
+        diver.role         = UserRole.DIVER;
+        diver.roles        = java.util.Set.of(UserRole.DIVER);
+        diver.persist();
+        return diver.id;
+    }
+
+    @Transactional
+    void cleanupUser(String email) {
+        User u = User.findByEmail(email);
+        if (u != null) {
+            DiveSlot.update("createdBy = null WHERE createdBy = ?1", u);
+            u.delete();
+        }
+    }
 
     /* ── Accès public ── */
 
@@ -55,13 +112,11 @@ class SlotResourceIT {
                 .statusCode(404);
     }
 
-    /* ── Création de créneau (ADMIN) ── */
+    /* ── Création de créneau ── */
 
     @Test
     @TestSecurity(user = "diver@test.com", roles = {"DIVER"})
     void createSlot_shouldReturn403_whenRoleIsDiver() {
-        // Un DIVER n'a pas le droit de créer un créneau (@RolesAllowed ADMIN/DIVE_DIRECTOR)
-        // le refus est fait avant tout appel à jwt.getName()
         given()
                 .contentType(ContentType.JSON)
                 .body("""
@@ -94,7 +149,7 @@ class SlotResourceIT {
                 .statusCode(401);
     }
 
-    /* ── Modification d'un créneau (date / heures) ── */
+    /* ── Modification d'un créneau ── */
 
     @Test
     void updateSlotInfo_shouldReturn401_withoutAuthentication() {
@@ -115,5 +170,93 @@ class SlotResourceIT {
                 .when().patch("/api/slots/1/info")
                 .then()
                 .statusCode(403);
+    }
+
+    /* ── Création pour le compte d'un autre DP (createdByUserId) ── */
+
+    @Test
+    @TestSecurity(user = "admin_proxy1@test.com", roles = {"ADMIN"})
+    void createSlot_asAdmin_withValidDpId_shouldReturn201AndAttributeSlotToDp() {
+        createAdminUser("admin_proxy1@test.com");
+        long dpId = createDiveDirector("dp_proxy_t1@test.com", "TARGET1");
+        try {
+            given()
+                    .contentType(ContentType.JSON)
+                    .body("""
+                          {"slotDate":"2099-08-01","startTime":"09:00","endTime":"12:00",
+                           "diverCount":6,"createdByUserId":%d}
+                          """.formatted(dpId))
+                    .when().post("/api/slots")
+                    .then()
+                    .statusCode(201)
+                    .body("slots[0].createdByName", equalTo("DP TARGET1"));
+        } finally {
+            cleanupUser("dp_proxy_t1@test.com");
+            cleanupUser("admin_proxy1@test.com");
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "dp_noproxy@test.com", roles = {"DIVE_DIRECTOR"})
+    void createSlot_asDiveDirector_withCreatedByUserId_shouldIgnoreFieldAndUseOwnAccount() {
+        // Un DIVE_DIRECTOR ne peut pas créer pour le compte d'autrui — le champ est ignoré
+        createDiveDirector("dp_noproxy@test.com", "NOPROXY");
+        long dpOtherId = createDiveDirector("dp_proxy_other@test.com", "OTHER");
+        try {
+            given()
+                    .contentType(ContentType.JSON)
+                    .body("""
+                          {"slotDate":"2099-08-02","startTime":"09:00","endTime":"12:00",
+                           "diverCount":4,"createdByUserId":%d}
+                          """.formatted(dpOtherId))
+                    .when().post("/api/slots")
+                    .then()
+                    .statusCode(201)
+                    // Le créneau doit être créé pour dp_noproxy (lui-même), pas dp_proxy_other
+                    .body("slots[0].createdByName", equalTo("DP NOPROXY"));
+        } finally {
+            cleanupUser("dp_proxy_other@test.com");
+            cleanupUser("dp_noproxy@test.com");
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "admin_proxy2@test.com", roles = {"ADMIN"})
+    void createSlot_asAdmin_withNonExistentDpId_shouldReturn404() {
+        createAdminUser("admin_proxy2@test.com");
+        try {
+            given()
+                    .contentType(ContentType.JSON)
+                    .body("""
+                          {"slotDate":"2099-09-01","startTime":"09:00","endTime":"12:00",
+                           "diverCount":5,"createdByUserId":999999}
+                          """)
+                    .when().post("/api/slots")
+                    .then()
+                    .statusCode(404);
+        } finally {
+            cleanupUser("admin_proxy2@test.com");
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "admin_proxy3@test.com", roles = {"ADMIN"})
+    void createSlot_asAdmin_withNonDpUserId_shouldReturn400() {
+        createAdminUser("admin_proxy3@test.com");
+        long diverId = createDiver("diver_proxy_t3@test.com");
+        try {
+            given()
+                    .contentType(ContentType.JSON)
+                    .body("""
+                          {"slotDate":"2099-09-02","startTime":"09:00","endTime":"12:00",
+                           "diverCount":5,"createdByUserId":%d}
+                          """.formatted(diverId))
+                    .when().post("/api/slots")
+                    .then()
+                    .statusCode(400);
+        } finally {
+            cleanupUser("diver_proxy_t3@test.com");
+            cleanupUser("admin_proxy3@test.com");
+        }
     }
 }

--- a/src/test/java/org/santalina/diving/integration/UserResourceIT.java
+++ b/src/test/java/org/santalina/diving/integration/UserResourceIT.java
@@ -327,6 +327,64 @@ class UserResourceIT {
         return "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "\\r") + "\"";
     }
 
+    /* ── GET /api/users/dive-directors ── */
+
+    @Test
+    void getDiveDirectors_shouldReturn401_withoutAuthentication() {
+        given()
+                .when().get("/api/users/dive-directors")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    @TestSecurity(user = "diver@test.com", roles = {"DIVER"})
+    void getDiveDirectors_shouldReturn403_whenDiver() {
+        given()
+                .when().get("/api/users/dive-directors")
+                .then()
+                .statusCode(403);
+    }
+
+    @Test
+    @TestSecurity(user = "dp@test.com", roles = {"DIVE_DIRECTOR"})
+    void getDiveDirectors_shouldReturn403_whenDiveDirector() {
+        given()
+                .when().get("/api/users/dive-directors")
+                .then()
+                .statusCode(403);
+    }
+
+    @Test
+    @TestSecurity(user = "admin@santalina.com", roles = {"ADMIN"})
+    void getDiveDirectors_shouldReturn200AndListDps_whenAdmin() {
+        String dpEmail = "dp_list_test@test.com";
+        createTestDiveDirector(dpEmail);
+        try {
+            given()
+                    .when().get("/api/users/dive-directors")
+                    .then()
+                    .statusCode(200)
+                    .body("$", instanceOf(java.util.List.class))
+                    .body("email", hasItem(dpEmail));
+        } finally {
+            deleteTestUser(dpEmail);
+        }
+    }
+
+    @jakarta.transaction.Transactional
+    void createTestDiveDirector(String email) {
+        org.santalina.diving.domain.User u = new org.santalina.diving.domain.User();
+        u.email        = email;
+        u.firstName    = "DP";
+        u.lastName     = "List Test";
+        u.passwordHash = "x";
+        u.activated    = true;
+        u.role         = org.santalina.diving.domain.UserRole.DIVE_DIRECTOR;
+        u.roles        = java.util.Set.of(org.santalina.diving.domain.UserRole.DIVE_DIRECTOR);
+        u.persist();
+    }
+
     @jakarta.transaction.Transactional
     void createTestUser(String email) {
         org.santalina.diving.domain.User u = new org.santalina.diving.domain.User();

--- a/src/test/java/org/santalina/diving/unit/SlotServiceTest.java
+++ b/src/test/java/org/santalina/diving/unit/SlotServiceTest.java
@@ -70,7 +70,7 @@ class SlotServiceTest {
         var request = new org.santalina.diving.dto.SlotDto.SlotRequest(
                 LocalDate.now().minusDays(1),
                 LocalTime.of(9, 0), LocalTime.of(11, 0),
-                5, null, null, null, null, null, null, null);
+                5, null, null, null, null, null, null, null, null);
         assertThrows(jakarta.ws.rs.BadRequestException.class,
                 () -> slotService.createSlot(request, null));
     }
@@ -80,7 +80,7 @@ class SlotServiceTest {
         var request = new org.santalina.diving.dto.SlotDto.SlotRequest(
                 LocalDate.now().plusDays(1),
                 LocalTime.of(9, 0), LocalTime.of(9, 0),
-                5, null, null, null, null, null, null, null);
+                5, null, null, null, null, null, null, null, null);
         assertThrows(jakarta.ws.rs.BadRequestException.class,
                 () -> slotService.createSlot(request, null));
     }
@@ -91,7 +91,7 @@ class SlotServiceTest {
         var request = new org.santalina.diving.dto.SlotDto.SlotRequest(
                 LocalDate.now().plusDays(1),
                 LocalTime.of(9, 0), LocalTime.of(9, 30),
-                5, null, null, null, null, null, null, null);
+                5, null, null, null, null, null, null, null, null);
         assertThrows(jakarta.ws.rs.BadRequestException.class,
                 () -> slotService.createSlot(request, null));
     }
@@ -102,7 +102,7 @@ class SlotServiceTest {
         var request = new org.santalina.diving.dto.SlotDto.SlotRequest(
                 LocalDate.now().plusDays(1),
                 LocalTime.of(0, 0), LocalTime.of(11, 0),
-                5, null, null, null, null, null, null, null);
+                5, null, null, null, null, null, null, null, null);
         assertThrows(jakarta.ws.rs.BadRequestException.class,
                 () -> slotService.createSlot(request, null));
     }
@@ -112,7 +112,7 @@ class SlotServiceTest {
         var request = new org.santalina.diving.dto.SlotDto.SlotRequest(
                 LocalDate.now().plusDays(1),
                 LocalTime.of(9, 0), LocalTime.of(11, 0),
-                30, null, null, null, null, null, null, null);
+                30, null, null, null, null, null, null, null, null);
         assertThrows(jakarta.ws.rs.BadRequestException.class,
                 () -> slotService.createSlot(request, null));
     }


### PR DESCRIPTION
…liste d'attente

- Ajout du champ optionnel `createdByUserId` dans SlotRequest : un ADMIN peut créer un créneau attribué à un directeur de plongée cible (filtré sur DIVE_DIRECTOR)
- Nouveau endpoint GET /api/users/dive-directors (ADMIN uniquement) pour lister les DP actifs disponibles
- Formulaire SlotForm : sélecteur "Créer pour le compte de…" visible pour ADMIN
- Fix liste d'attente : le chip "plongée(s)" n'affiche plus "0 plongée"
- Refactoring SlotResource : jwt.getName() → identity.getPrincipal().getName() (compatibilité @TestSecurity)
- 8 nouveaux tests d'intégration (SlotResourceIT + UserResourceIT)
- Aide en ligne mise à jour (HelpPage)