### PR TITLE
feat: sort inscription report CSV by club and add CODEP notice in email

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌊 Santalina — Système de Réservation
+# Santalina — Système de Réservation
 
 [![Dernière version](https://img.shields.io/github/v/release/sclaudel/santalina?label=derni%C3%A8re%20version&logo=github&color=blue&include_prereleases)](https://github.com/sclaudel/santalina/releases/latest)
 [![Licence MIT](https://img.shields.io/badge/licence-MIT-green)](./LICENSE)
@@ -7,30 +7,31 @@
 
 Application de réservation de créneaux de plongée en lac, développée avec **Quarkus 3.32.2** (Java 21) et **React 19** (TypeScript).
 
-## ✨ Fonctionnalités
+## Fonctionnalités
 
-- 📅 **Calendrier public** : vues Jour, Semaine et Mois **chronologiques** sans authentification
-- 🔐 **Authentification JWT** : login, inscription avec **activation par email** (lien 24 h), reset de mot de passe par email
-- 🛡️ **RGPD** : consentement explicite collecté à l'inscription- 🏆 **Certification d'appartenance club** : case obligatoire à l’inscription (« Je certifie sur l’honneur être membre du club indiqué ») — le club est également obligatoire
-- 🔒 **Politique de mot de passe robuste** : minimum 8 caractères, au moins 1 majuscule, 1 chiffre et 1 caractère spécial (appliquée à la création de compte, la réinitialisation et le changement — sans impact sur les mots de passe existants)- 👥 **3 rôles** (cumulables) :
-  - `ADMIN` 🔑 : configuration, tous les créneaux, gestion des utilisateurs
-  - `DIVE_DIRECTOR` 🤿 : création et suppression de ses propres créneaux, gestion des plongeurs sur ses créneaux et ceux où il est assigné comme DP, auto-assignation comme DP sur tout créneau sans directeur
-  - `DIVER` 🏊 : consultation + inscription libre sur les créneaux ouverts
-- ⏰ **Créneaux** : 1h min, 10h max, résolution 15 min, chevauchements affichés côte à côte
-- 🤿 **Plongeurs** : ajout/modification/suppression (nom, prénom capitalisé, niveau) sur chaque créneau
-- 🎯 **Capacité configurable** : max 25 plongeurs simultanés (modifiable par l'admin)
-- 📋 **Liste d'attente** : inscription libre pour les plongeurs (DIVER/DIVE_DIRECTOR non créateur), validation/refus par le DP responsable, badge de notification
-- 🔓 **Inscriptions libres** : le DP assigné (ou le créateur du créneau) peut ouvrir les inscriptions avec une date d'ouverture optionnelle — les plongeurs s'inscrivent eux-mêmes et peuvent annuler leur inscription (avertissement si < 48 h avant la sortie)
-- 🤿 **Auto-assignation DP** : un directeur de plongée peut se désigner lui-même comme DP sur n'importe quel créneau sans directeur, depuis le panneau de détails du calendrier, sans passer par le formulaire d'ajout
-- 🗂️ **Organisation des palanquées** : drag-and-drop, gestion des aptitudes/profondeurs, export Excel fiche de sécurité, export CSV liste des plongeurs avec emails
-- 🔒 **Normalisation des données** : prénoms capitalisés (composés inclus), emails en minuscules — à la saisie et à l'import backup
-- 🐳 **Docker-ready** : Dockerfile multi-stage + docker-compose
-- 🗄️ **Double base de données** : H2 fichier (dev) / PostgreSQL (prod) — couche d'abstraction Panache
-- 📊 **Statistiques** (ADMIN) : tableau de bord avec camemberts, histogrammes et tableaux
-- 💾 **Sauvegarde / restauration** : export JSON complet ou config+utilisateurs, import avec normalisation automatique
-- 🚧 **Mode maintenance** (ADMIN) : désactivation des connexions non-admin en un clic — les utilisateurs reçoivent un message de maintenance à la connexion
-- 🔗 **Liens directs** : partage d'un lien vers une date précise (`?date=YYYY-MM-DD&view=day|week|month`) ou directement vers un créneau (`?slot=ID`) — les utilisateurs non connectés sont redirigés vers le bon contenu après authentification
-
+- **Calendrier public** : vues Jour, Semaine et Mois chronologiques sans authentification
+- **Authentification JWT** : login, inscription avec activation par email (lien 24 h), reset de mot de passe par email
+- **RGPD** : consentement explicite collecté à l'inscription
+- **Certification d'appartenance club** : case obligatoire à l'inscription (club obligatoire)
+- **Politique de mot de passe** : minimum 8 caractères, au moins 1 majuscule, 1 chiffre et 1 caractère spécial
+- **3 rôles** (cumulables) :
+  - `ADMIN` : configuration, tous les créneaux, gestion des utilisateurs
+  - `DIVE_DIRECTOR` : création et suppression de ses propres créneaux, gestion des plongeurs
+  - `DIVER` : consultation + inscription libre sur les créneaux ouverts
+- **Créneaux** : 1h min, 10h max, résolution 15 min, chevauchements affichés côte à côte
+- **Plongeurs** : ajout/modification/suppression sur chaque créneau
+- **Capacité configurable** : max 25 plongeurs simultanés (modifiable par l'admin)
+- **Liste d'attente** : inscription libre, validation/refus par le DP responsable
+- **Inscriptions libres** : le DP assigné peut ouvrir les inscriptions avec date d'ouverture optionnelle
+- **Organisation des palanquées** : drag-and-drop, gestion des aptitudes, export Excel fiche de sécurité, export CSV
+- **Normalisation des données** : prénoms capitalisés, emails en minuscules
+- **Docker-ready** : Dockerfile multi-stage + docker-compose
+- **Double base de données** : H2 fichier (dev) / PostgreSQL (prod)
+- **Statistiques** (ADMIN) : tableau de bord avec camemberts, histogrammes et tableaux
+- **Sauvegarde / restauration** : export JSON complet ou config+utilisateurs, import avec normalisation automatique
+- **Mode maintenance** (ADMIN) : désactivation des connexions non-admin en un clic
+- **Rapport périodique d'inscriptions** (ADMIN) : envoi automatique d'un fichier CSV des nouvelles inscriptions trié par club d'appartenance, avec période paramétrable (hebdomadaire, mensuel, etc.) ; le mail informe explicitement le destinataire qu'il peut signaler au CODEP tout plongeur hors de son club ; déclenchement manuel sur période personnalisée avec filtre par club, envoi par e-mail ou téléchargement direct
+- **Liens directs** : partage d'un lien vers une date précise ou directement vers un créneau
 ---
 
 ## 🚀 Démarrage rapide (développement)
@@ -128,6 +129,9 @@ docker compose up --build
 | `PUT` | `/api/config/max-divers` | ADMIN | Max plongeurs |
 | `PUT` | `/api/config/site-name` | ADMIN | Nom du site |
 | `PUT` | `/api/config/maintenance-mode` | ADMIN | Activer/désactiver le mode maintenance |
+| `PUT` | `/api/config/report-email-settings` | ADMIN | Configurer le rapport périodique d'inscriptions |
+| `POST` | `/api/config/report-email-send` | ADMIN | Envoyer le rapport manuellement (période + destinataires) |
+| `GET` | `/api/config/report-email-download?from=&to=` | ADMIN | Télécharger le rapport CSV sur une période |
 | `GET` | `/api/stats?from=YYYY-MM-DD&to=YYYY-MM-DD` | ADMIN | Statistiques agrégées (période optionnelle) |
 
 Documentation Swagger : **http://localhost:8085/q/swagger-ui**
@@ -209,9 +213,10 @@ src/main/
 │   ├── domain/          # Entités JPA (User, DiveSlot, SlotDiver, WaitingListEntry, Palanquee, AppConfigEntry)
 │   ├── dto/             # Records Java (request/response)
 │   ├── exception/       # GlobalExceptionMapper
-│   ├── mail/            # PasswordResetMailer, ActivationMailer, WaitingListMailer
+│   ├── mail/            # PasswordResetMailer, ActivationMailer, WaitingListMailer, RegistrationReportMailer
 │   ├── resource/        # JAX-RS endpoints (AuthResource, SlotResource, SlotDiverResource,
 │   │                   #   WaitingListResource, PalanqueeResource, UserResource, StatsResource, BackupResource…)
+│   ├── scheduler/       # RegistrationReportScheduler (rapport périodique inscriptions)
 │   ├── security/        # JwtUtil, PasswordUtil (BCrypt), NameUtil (capitalisation)
 │   ├── service/         # AuthService, UserService, ConfigService, BackupService
 │   └── startup/         # AppStartup (init admin + config)

--- a/src/main/java/org/santalina/diving/dto/ConfigDto.java
+++ b/src/main/java/org/santalina/diving/dto/ConfigDto.java
@@ -37,7 +37,11 @@ public class ConfigDto {
             boolean notifSafetyReminderEnabled,
             int safetyReminderDelayDays,
             String safetyReminderEmailBody,
-            boolean maintenanceMode
+            boolean maintenanceMode,
+            boolean reportEmailEnabled,
+            int reportEmailPeriodDays,
+            String reportEmailRecipients,
+            String reportEmailLastSent
     ) {}
 
     public record UpdateMaxRecurringMonthsRequest(
@@ -86,5 +90,18 @@ public class ConfigDto {
             @NotNull Boolean notifSafetyReminderEnabled,
             @NotNull @Min(1) @jakarta.validation.constraints.Max(30) Integer safetyReminderDelayDays,
             String safetyReminderEmailBody
+    ) {}
+
+    public record UpdateReportEmailSettingsRequest(
+            @NotNull Boolean reportEmailEnabled,
+            @NotNull @Min(1) @jakarta.validation.constraints.Max(365) Integer reportEmailPeriodDays,
+            String reportEmailRecipients
+    ) {}
+
+    public record ManualReportSendRequest(
+            @NotBlank String fromDate,
+            @NotBlank String toDate,
+            String recipients,
+            String club
     ) {}
 }

--- a/src/main/java/org/santalina/diving/mail/RegistrationReportMailer.java
+++ b/src/main/java/org/santalina/diving/mail/RegistrationReportMailer.java
@@ -1,0 +1,174 @@
+package org.santalina.diving.mail;
+
+import io.quarkus.mailer.Mail;
+import io.quarkus.mailer.Mailer;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+import org.santalina.diving.domain.User;
+import org.santalina.diving.service.ConfigService;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Génère un rapport CSV des nouvelles inscriptions et l'envoie par e-mail
+ * aux destinataires configurés dans l'administration.
+ */
+@ApplicationScoped
+public class RegistrationReportMailer {
+
+    private static final Logger LOG = Logger.getLogger(RegistrationReportMailer.class);
+    private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+
+    @Inject
+    Mailer mailer;
+
+    @Inject
+    ConfigService configService;
+
+    /**
+     * Envoie le rapport des inscriptions aux destinataires configurés.
+     *
+     * @param since date à partir de laquelle récupérer les inscriptions
+     * @param users liste des utilisateurs inscrits depuis {@code since}
+     */
+    public void sendReport(LocalDateTime since, List<User> users) {
+        String recipientsCsv = configService.getReportEmailRecipients();
+        if (recipientsCsv == null || recipientsCsv.isBlank()) {
+            LOG.warn("Rapport d'inscriptions : aucun destinataire configuré, envoi annulé.");
+            return;
+        }
+        sendReport(since, users, recipientsCsv);
+    }
+
+    /**
+     * Envoie le rapport des inscriptions aux destinataires explicitement fournis.
+     *
+     * @param since        date de référence (pour le sujet du mail)
+     * @param users        liste des utilisateurs à inclure dans le rapport
+     * @param recipientsCsv destinataires séparés par virgule ou point-virgule
+     */
+    public void sendReport(LocalDateTime since, List<User> users, String recipientsCsv) {
+        List<String> recipients = Arrays.stream(recipientsCsv.split("[,;]"))
+                .map(String::trim)
+                .filter(s -> !s.isBlank())
+                .collect(Collectors.toList());
+
+        if (recipients.isEmpty()) {
+            LOG.warn("Rapport d'inscriptions : liste de destinataires vide après analyse, envoi annulé.");
+            return;
+        }
+
+        String siteName = configService.getSiteName();
+        byte[] csv = buildCsvBytes(users);
+
+        String sinceFormatted = since.format(DATE_FMT);
+        String subject = "[" + siteName + "] Rapport des nouvelles inscriptions depuis le " + sinceFormatted;
+
+        int count = users.size();
+        String body = buildEmailBody(siteName, sinceFormatted, count);
+
+        String fileName = "inscriptions_" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmm")) + ".csv";
+
+        for (String recipient : recipients) {
+            try {
+                mailer.send(
+                        Mail.withHtml(recipient, subject, body)
+                                .addAttachment(fileName, csv, "text/csv; charset=UTF-8")
+                );
+                LOG.infof("Rapport d'inscriptions envoyé à %s (%d inscrit(s) depuis le %s)", recipient, count, sinceFormatted);
+            } catch (Exception e) {
+                LOG.errorf(e, "Erreur lors de l'envoi du rapport d'inscriptions à %s", recipient);
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Génération CSV
+    // -------------------------------------------------------------------------
+
+    /**
+     * Génère le contenu CSV sous forme de tableau d'octets (UTF-8 avec BOM pour Excel).
+     */
+    public byte[] buildCsvBytes(List<User> users) {
+        return buildCsv(users).getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Génère le contenu CSV sous forme de chaîne de caractères (UTF-8 avec BOM pour Excel).
+     */
+    public String buildCsv(List<User> users) {
+        StringBuilder sb = new StringBuilder();
+        // BOM UTF-8 pour compatibilité Excel
+        sb.append('\uFEFF');
+        sb.append("Club;Nom;Prénom;E-mail;Licence;Date d'inscription\n");
+        users.stream()
+             .sorted(Comparator.comparing(
+                     (User u) -> u.club != null ? u.club : "\uFFFF",
+                     String.CASE_INSENSITIVE_ORDER)
+                     .thenComparing(u -> u.lastName != null ? u.lastName : "")
+                     .thenComparing(u -> u.firstName != null ? u.firstName : ""))
+             .forEach(user -> sb
+                     .append(csvEscape(user.club)).append(';')
+                     .append(csvEscape(user.lastName)).append(';')
+                     .append(csvEscape(user.firstName)).append(';')
+                     .append(csvEscape(user.email)).append(';')
+                     .append(csvEscape(user.licenseNumber)).append(';')
+                     .append(user.createdAt != null ? user.createdAt.format(DATE_FMT) : "")
+                     .append('\n'));
+        return sb.toString();
+    }
+
+    private String csvEscape(String value) {
+        if (value == null) return "";
+        if (value.contains(";") || value.contains("\"") || value.contains("\n")) {
+            return "\"" + value.replace("\"", "\"\"") + "\"";
+        }
+        return value;
+    }
+
+    // -------------------------------------------------------------------------
+    // Corps du mail HTML
+    // -------------------------------------------------------------------------
+
+    private String buildEmailBody(String siteName, String sinceFormatted, int count) {
+        return """
+                <!DOCTYPE html>
+                <html lang="fr">
+                <head>
+                  <meta charset="UTF-8" />
+                  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                </head>
+                <body style="font-family:Arial,sans-serif;max-width:600px;margin:0 auto;">
+                  <h2 style="color:#1e40af;">Rapport des nouvelles inscriptions</h2>
+                  <p>Bonjour,</p>
+                  <p>
+                    Vous recevez ce message en tant qu'<strong>administrateur du site</strong>,
+                    <strong>président de club</strong> ou <strong>responsable technique</strong>.
+                  </p>
+                  <p>
+                    Vous trouverez en pièce jointe la liste des <strong>%d nouvelle(s) inscription(s)</strong>
+                    enregistrée(s) sur <strong>%s</strong> depuis le <strong>%s</strong>.
+                    Les inscriptions sont triées par club d'appartenance.
+                  </p>
+                  <div style="background:#fef9c3;border:1px solid #fbbf24;border-radius:6px;padding:12px 16px;margin:16px 0;">
+                    <strong>⚠️ Action requise si nécessaire</strong><br />
+                    Si un plongeur listé ne fait pas partie de votre club ou si son inscription vous semble
+                    incorrecte, merci de le signaler auprès du <strong>comité départemental (CODEP)</strong>
+                    compétent afin de régulariser la situation.
+                  </div>
+                  <p>Ce rapport est généré automatiquement. Pour modifier sa fréquence ou ses destinataires,
+                  rendez-vous dans les paramètres administrateurs, rubrique <em>Rapport périodique</em>.</p>
+                  <hr style="border:1px solid #e5e7eb;margin-top:30px;" />
+                  <p style="color:#6b7280;font-size:12px;">Système de réservation — %s</p>
+                </body>
+                </html>
+                """.formatted(count, siteName, sinceFormatted, siteName);
+    }
+}

--- a/src/main/java/org/santalina/diving/resource/ConfigResource.java
+++ b/src/main/java/org/santalina/diving/resource/ConfigResource.java
@@ -1,14 +1,22 @@
 package org.santalina.diving.resource;
 
+import org.santalina.diving.domain.User;
 import org.santalina.diving.dto.ConfigDto.*;
+import org.santalina.diving.mail.RegistrationReportMailer;
 import org.santalina.diving.service.ConfigService;
 import jakarta.annotation.security.PermitAll;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Path("/api/config")
 @Produces(MediaType.APPLICATION_JSON)
@@ -18,6 +26,9 @@ public class ConfigResource {
 
     @Inject
     ConfigService configService;
+
+    @Inject
+    RegistrationReportMailer reportMailer;
 
     @GET
     @PermitAll
@@ -165,5 +176,70 @@ public class ConfigResource {
     @RolesAllowed("ADMIN")
     public ConfigResponse updateMaintenanceMode(@Valid UpdateBooleanRequest request) {
         return configService.updateMaintenanceMode(request.value());
+    }
+
+    @PUT
+    @Path("/report-email-settings")
+    @RolesAllowed("ADMIN")
+    public ConfigResponse updateReportEmailSettings(@Valid UpdateReportEmailSettingsRequest request) {
+        return configService.updateReportEmailSettings(
+                request.reportEmailEnabled(),
+                request.reportEmailPeriodDays(),
+                request.reportEmailRecipients()
+        );
+    }
+
+    @POST
+    @Path("/report-email-send")
+    @RolesAllowed("ADMIN")
+    @Transactional
+    public Response sendManualReport(@Valid ManualReportSendRequest request) {
+        LocalDateTime fromDt = LocalDate.parse(request.fromDate()).atStartOfDay();
+        LocalDateTime toDt   = LocalDate.parse(request.toDate()).plusDays(1).atStartOfDay();
+
+        List<User> users = User.<User>find(
+                "activated = true AND createdAt >= ?1 AND createdAt < ?2", fromDt, toDt
+        ).list();
+        users = filterByClub(users, request.club());
+
+        String recipients = (request.recipients() != null && !request.recipients().isBlank())
+                ? request.recipients()
+                : configService.getReportEmailRecipients();
+
+        reportMailer.sendReport(fromDt, users, recipients);
+
+        return Response.ok("{\"count\":" + users.size() + "}").type(MediaType.APPLICATION_JSON).build();
+    }
+
+    @GET
+    @Path("/report-email-download")
+    @Produces("text/csv")
+    @RolesAllowed("ADMIN")
+    @Transactional
+    public Response downloadReport(@QueryParam("from") String from, @QueryParam("to") String to,
+                                    @QueryParam("club") String club) {
+        LocalDateTime fromDt = LocalDate.parse(from).atStartOfDay();
+        LocalDateTime toDt   = LocalDate.parse(to).plusDays(1).atStartOfDay();
+
+        List<User> users = User.<User>find(
+                "activated = true AND createdAt >= ?1 AND createdAt < ?2", fromDt, toDt
+        ).list();
+        users = filterByClub(users, club);
+
+        byte[] csvBytes = reportMailer.buildCsvBytes(users);
+        String clubSuffix = (club != null && !club.isBlank()) ? "_" + club.replaceAll("[^a-zA-Z0-9_-]", "_") : "";
+        String filename = "inscriptions_" + from + "_" + to + clubSuffix + ".csv";
+
+        return Response.ok(csvBytes)
+                .header("Content-Disposition", "attachment; filename=\"" + filename + "\"")
+                .header("Content-Type", "text/csv; charset=UTF-8")
+                .build();
+    }
+
+    private List<User> filterByClub(List<User> users, String club) {
+        if (club == null || club.isBlank()) return users;
+        return users.stream()
+                .filter(u -> club.equalsIgnoreCase(u.club))
+                .collect(java.util.stream.Collectors.toList());
     }
 }

--- a/src/main/java/org/santalina/diving/scheduler/RegistrationReportScheduler.java
+++ b/src/main/java/org/santalina/diving/scheduler/RegistrationReportScheduler.java
@@ -1,0 +1,100 @@
+package org.santalina.diving.scheduler;
+
+import io.quarkus.scheduler.Scheduled;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.jboss.logging.Logger;
+import org.santalina.diving.domain.User;
+import org.santalina.diving.mail.RegistrationReportMailer;
+import org.santalina.diving.service.ConfigService;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+/**
+ * Tâche planifiée : envoie périodiquement un rapport CSV des nouvelles inscriptions
+ * par e-mail aux destinataires configurés dans l'administration.
+ *
+ * La fréquence de vérification est horaire ; l'envoi effectif se produit uniquement
+ * lorsque le délai paramétré (en jours) est écoulé depuis le dernier envoi.
+ */
+@ApplicationScoped
+public class RegistrationReportScheduler {
+
+    private static final Logger LOG = Logger.getLogger(RegistrationReportScheduler.class);
+    private static final DateTimeFormatter ISO_FMT = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+    @Inject
+    ConfigService configService;
+
+    @Inject
+    RegistrationReportMailer reportMailer;
+
+    @Scheduled(every = "1h", delayed = "5m")
+    @Transactional
+    public void checkAndSendReport() {
+        if (!configService.isReportEmailEnabled()) {
+            return;
+        }
+
+        int periodDays = configService.getReportEmailPeriodDays();
+        if (periodDays <= 0) {
+            return;
+        }
+
+        String recipients = configService.getReportEmailRecipients();
+        if (recipients == null || recipients.isBlank()) {
+            return;
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime since = resolveLastSent(now, periodDays);
+
+        // Pas encore le moment d'envoyer
+        if (since == null) {
+            return;
+        }
+
+        // Récupérer les utilisateurs activés inscrits depuis 'since'
+        LocalDateTime sinceForQuery = since;
+        List<User> newUsers = User.<User>find("activated = true AND createdAt >= ?1", sinceForQuery).list();
+
+        if (newUsers.isEmpty()) {
+            LOG.infof("Rapport d'inscriptions : aucun nouvel inscrit depuis le %s, envoi ignoré.", since.format(ISO_FMT));
+        } else {
+            reportMailer.sendReport(since, newUsers);
+        }
+
+        // Mise à jour de la date de dernier envoi dans tous les cas
+        configService.updateReportEmailLastSent(now.format(ISO_FMT));
+    }
+
+    /**
+     * Détermine la date de référence pour la requête utilisateurs.
+     *
+     * @return la date depuis laquelle chercher, ou {@code null} si l'envoi n'est pas encore dû.
+     */
+    private LocalDateTime resolveLastSent(LocalDateTime now, int periodDays) {
+        String lastSentStr = configService.getReportEmailLastSent();
+
+        if (lastSentStr == null || lastSentStr.isBlank()) {
+            // Premier envoi : on considère la période précédente
+            return now.minusDays(periodDays);
+        }
+
+        try {
+            LocalDateTime lastSent = LocalDateTime.parse(lastSentStr, ISO_FMT);
+            LocalDateTime nextDue  = lastSent.plusDays(periodDays);
+            if (now.isBefore(nextDue)) {
+                return null; // Pas encore l'heure
+            }
+            return lastSent;
+        } catch (DateTimeParseException e) {
+            LOG.warnf("Rapport d'inscriptions : impossible de lire la date du dernier envoi (%s), réinitialisation.", lastSentStr);
+            return now.minusDays(periodDays);
+        }
+    }
+}

--- a/src/main/java/org/santalina/diving/service/ConfigService.java
+++ b/src/main/java/org/santalina/diving/service/ConfigService.java
@@ -50,6 +50,12 @@ public class ConfigService {
     private static final String KEY_SAFETY_REMINDER_DELAY_DAYS = "notif.safety_reminder.delay_days";
     private static final String KEY_SAFETY_REMINDER_EMAIL_BODY = "notif.safety_reminder.email_body";
 
+    // -- Rapport périodique d'inscriptions --
+    private static final String KEY_REPORT_EMAIL_ENABLED     = "report.email.enabled";
+    private static final String KEY_REPORT_EMAIL_PERIOD_DAYS = "report.email.period.days";
+    private static final String KEY_REPORT_EMAIL_RECIPIENTS  = "report.email.recipients";
+    private static final String KEY_REPORT_EMAIL_LAST_SENT   = "report.email.last.sent";
+
     private static final String DEFAULT_SAFETY_REMINDER_BODY =
         "Ce rappel vous est envoyé car vous êtes le directeur de plongée du créneau du {slotDate} sur le site {siteName}.\n\n" +
         "Pensez à transmettre la fiche de sécurité remplie à votre club si ce n'est pas encore fait.";
@@ -179,6 +185,20 @@ public class ConfigService {
         return getStringValue(KEY_SAFETY_REMINDER_EMAIL_BODY, DEFAULT_SAFETY_REMINDER_BODY);
     }
 
+    // -- Getters rapport périodique --
+    public boolean isReportEmailEnabled() {
+        return Boolean.parseBoolean(getStringValue(KEY_REPORT_EMAIL_ENABLED, "false"));
+    }
+    public int getReportEmailPeriodDays() {
+        return getIntValue(KEY_REPORT_EMAIL_PERIOD_DAYS, 7);
+    }
+    public String getReportEmailRecipients() {
+        return getStringValue(KEY_REPORT_EMAIL_RECIPIENTS, "");
+    }
+    public String getReportEmailLastSent() {
+        return getStringValue(KEY_REPORT_EMAIL_LAST_SENT, "");
+    }
+
     public ConfigResponse getConfig() {
         return new ConfigResponse(
                 getMaxDivers(), getSlotMinHours(), getSlotMaxHours(),
@@ -199,7 +219,11 @@ public class ConfigService {
                 isNotifSafetyReminderEnabled(),
                 getSafetyReminderDelayDays(),
                 getSafetyReminderEmailBody(),
-                isMaintenanceMode()
+                isMaintenanceMode(),
+                isReportEmailEnabled(),
+                getReportEmailPeriodDays(),
+                getReportEmailRecipients(),
+                getReportEmailLastSent()
         );
     }
 
@@ -264,6 +288,19 @@ public class ConfigService {
     public ConfigResponse updateMaintenanceMode(boolean value) {
         forceUpsert(KEY_MAINTENANCE_MODE, String.valueOf(value));
         return getConfig();
+    }
+
+    @Transactional
+    public ConfigResponse updateReportEmailSettings(boolean enabled, int periodDays, String recipients) {
+        forceUpsert(KEY_REPORT_EMAIL_ENABLED,     String.valueOf(enabled));
+        forceUpsert(KEY_REPORT_EMAIL_PERIOD_DAYS, String.valueOf(periodDays));
+        forceUpsert(KEY_REPORT_EMAIL_RECIPIENTS,  recipients != null ? recipients.trim() : "");
+        return getConfig();
+    }
+
+    @Transactional
+    public void updateReportEmailLastSent(String isoDateTime) {
+        forceUpsert(KEY_REPORT_EMAIL_LAST_SENT, isoDateTime);
     }
     @Transactional
     public ConfigResponse updateBookingHours(int openHour, int closeHour) {
@@ -365,6 +402,10 @@ public class ConfigService {
         upsertIfMissing(KEY_SAFETY_REMINDER_DELAY_DAYS, "3");
         upsertIfMissing(KEY_SAFETY_REMINDER_EMAIL_BODY, DEFAULT_SAFETY_REMINDER_BODY);
         upsertIfMissing(KEY_MAINTENANCE_MODE,           "false");
+        upsertIfMissing(KEY_REPORT_EMAIL_ENABLED,       "false");
+        upsertIfMissing(KEY_REPORT_EMAIL_PERIOD_DAYS,   "7");
+        upsertIfMissing(KEY_REPORT_EMAIL_RECIPIENTS,    "");
+        upsertIfMissing(KEY_REPORT_EMAIL_LAST_SENT,     "");
     }
 
     // ---- Helpers privés ----

--- a/src/main/webui/src/pages/AdminPage.tsx
+++ b/src/main/webui/src/pages/AdminPage.tsx
@@ -74,6 +74,21 @@ export function AdminPage() {
   const [safetyReminderEmailBody, setSafetyReminderEmailBody] = useState('');
   const [notifSettingsLoading, setNotifSettingsLoading] = useState(false);
 
+  // Rapport périodique d'inscriptions par e-mail
+  const [reportEmailEnabled, setReportEmailEnabled]       = useState(false);
+  const [reportEmailPeriodDays, setReportEmailPeriodDays] = useState(7);
+  const [reportEmailRecipients, setReportEmailRecipients] = useState('');
+  const [reportEmailLoading, setReportEmailLoading]       = useState(false);
+  // Déclenchement manuel du rapport
+  const today = new Date().toISOString().slice(0, 10);
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  const [manualReportFrom, setManualReportFrom]           = useState(thirtyDaysAgo);
+  const [manualReportTo, setManualReportTo]               = useState(today);
+  const [manualReportClub, setManualReportClub]           = useState('');
+  const [manualReportRecipients, setManualReportRecipients] = useState('');
+  const [manualReportSendLoading, setManualReportSendLoading] = useState(false);
+  const [manualReportDownloadLoading, setManualReportDownloadLoading] = useState(false);
+
   // Recherche et pagination utilisateurs
   const [userSearch, setUserSearch]   = useState('');
   const [userPage, setUserPage]       = useState(1);
@@ -136,6 +151,9 @@ export function AdminPage() {
       setNotifSafetyReminder(c.notifSafetyReminderEnabled ?? false);
       setSafetyReminderDelayDays(c.safetyReminderDelayDays ?? 3);
       setSafetyReminderEmailBody(c.safetyReminderEmailBody ?? '');
+      setReportEmailEnabled(c.reportEmailEnabled ?? false);
+      setReportEmailPeriodDays(c.reportEmailPeriodDays ?? 7);
+      setReportEmailRecipients(c.reportEmailRecipients ?? '');
     } catch {
       setError('Erreur lors du chargement des données');
     }
@@ -391,6 +409,37 @@ export function AdminPage() {
       setMsg('Paramètres de notifications enregistrés.');
     } catch (err: unknown) { setError(getErrorMessage(err)); }
     finally { setNotifSettingsLoading(false); }
+  };
+
+  const handleUpdateReportEmailSettings = async () => {
+    setMsg(''); setError(''); setReportEmailLoading(true);
+    try {
+      const updated = await adminService.updateReportEmailSettings({
+        reportEmailEnabled,
+        reportEmailPeriodDays,
+        reportEmailRecipients,
+      });
+      setConfig(updated);
+      setMsg('Paramètres du rapport périodique enregistrés.');
+    } catch (err: unknown) { setError(getErrorMessage(err)); }
+    finally { setReportEmailLoading(false); }
+  };
+
+  const handleManualReportSend = async () => {
+    setMsg(''); setError(''); setManualReportSendLoading(true);
+    try {
+      const result = await adminService.sendManualReport(manualReportFrom, manualReportTo, manualReportRecipients, manualReportClub || undefined);
+      setMsg(`Rapport envoyé (${result.count} inscription(s) sur la période).`);
+    } catch (err: unknown) { setError(getErrorMessage(err)); }
+    finally { setManualReportSendLoading(false); }
+  };
+
+  const handleManualReportDownload = async () => {
+    setMsg(''); setError(''); setManualReportDownloadLoading(true);
+    try {
+      await adminService.downloadReport(manualReportFrom, manualReportTo, manualReportClub || undefined);
+    } catch (err: unknown) { setError(getErrorMessage(err)); }
+    finally { setManualReportDownloadLoading(false); }
   };
 
   const toggleCreateRole = (role: UserRole) => {
@@ -824,6 +873,110 @@ export function AdminPage() {
         <button className="btn btn-primary" onClick={handleUpdateNotifSettings} disabled={notifSettingsLoading}>
           {notifSettingsLoading ? '...' : '💾 Enregistrer les paramètres'}
         </button>
+      </div>
+
+      {/* ── Rapport périodique d'inscriptions ── */}
+      <div className="admin-section">
+        <h2>📊 Rapport périodique des inscriptions</h2>
+        <p style={{ color: '#6b7280', fontSize: 13, marginBottom: 16 }}>
+          Envoyez automatiquement un fichier CSV listant les nouvelles inscriptions
+          (nom, prénom, e-mail, licence, club, date d'inscription) à une liste d'adresses configurables.
+          Le premier envoi couvre la période précédant la date d'activation.
+        </p>
+
+        <label style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 16, cursor: 'pointer' }}>
+          <input
+            type="checkbox"
+            checked={reportEmailEnabled}
+            onChange={e => setReportEmailEnabled(e.target.checked)}
+          />
+          <span>Activer l'envoi automatique du rapport</span>
+          <span className={`badge ${reportEmailEnabled ? 'badge-success' : 'badge-muted'}`}>
+            {reportEmailEnabled ? 'Activé' : 'Désactivé'}
+          </span>
+        </label>
+
+        {reportEmailEnabled && (
+          <div style={{ background: '#f0f9ff', border: '1px solid #bae6fd', borderRadius: 8, padding: 16, marginBottom: 16 }}>
+            <div className="form-group" style={{ marginBottom: 12 }}>
+              <label style={{ fontSize: 13 }}>Période d'envoi (en jours)</label>
+              <input
+                type="number"
+                min={1}
+                max={365}
+                value={reportEmailPeriodDays}
+                onChange={e => setReportEmailPeriodDays(Number(e.target.value))}
+                style={{ width: 90 }}
+              />
+              <span style={{ color: '#6b7280', fontSize: 12, marginTop: 4, display: 'block' }}>
+                Ex : 7 = hebdomadaire, 30 = mensuel
+              </span>
+            </div>
+            <div className="form-group">
+              <label style={{ fontSize: 13 }}>Destinataires (séparés par une virgule ou un point-virgule)</label>
+              <input
+                type="text"
+                value={reportEmailRecipients}
+                onChange={e => setReportEmailRecipients(e.target.value)}
+                placeholder="secretaire@club.fr, president@club.fr"
+                style={{ width: '100%' }}
+              />
+            </div>
+            {config?.reportEmailLastSent && (
+              <div style={{ fontSize: 12, color: '#6b7280', marginTop: 8 }}>
+                Dernier envoi : <strong>{config.reportEmailLastSent.replace('T', ' ').substring(0, 16)}</strong>
+              </div>
+            )}
+          </div>
+        )}
+
+        <button className="btn btn-primary" onClick={handleUpdateReportEmailSettings} disabled={reportEmailLoading}>
+          {reportEmailLoading ? '...' : '💾 Enregistrer le rapport périodique'}
+        </button>
+
+        {/* Déclenchement manuel */}
+        <hr style={{ border: '1px solid #e5e7eb', margin: '24px 0' }} />
+        <h3 style={{ marginBottom: 12 }}>📤 Envoi ou téléchargement manuel</h3>
+        <p style={{ color: '#6b7280', fontSize: 13, marginBottom: 16 }}>
+          Générez un rapport CSV pour une période personnalisée, à envoyer par e-mail ou à télécharger directement.
+        </p>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16, marginBottom: 16 }}>
+          <div className="form-group" style={{ minWidth: 160 }}>
+            <label style={{ fontSize: 13 }}>Du</label>
+            <input type="date" value={manualReportFrom} onChange={e => setManualReportFrom(e.target.value)} />
+          </div>
+          <div className="form-group" style={{ minWidth: 160 }}>
+            <label style={{ fontSize: 13 }}>Au</label>
+            <input type="date" value={manualReportTo} onChange={e => setManualReportTo(e.target.value)} />
+          </div>
+          <div className="form-group" style={{ minWidth: 180 }}>
+            <label style={{ fontSize: 13 }}>Club (laisser vide = tous)</label>
+            <select value={manualReportClub} onChange={e => setManualReportClub(e.target.value)}>
+              <option value="">— Tous les clubs —</option>
+              {(config?.clubs ?? []).map(c => (
+                <option key={c} value={c}>{c}</option>
+              ))}
+            </select>
+          </div>
+          <div className="form-group" style={{ flex: 1, minWidth: 220 }}>
+            <label style={{ fontSize: 13 }}>Destinataires (laisser vide = destinataires configurés)</label>
+            <input
+              type="text"
+              value={manualReportRecipients}
+              onChange={e => setManualReportRecipients(e.target.value)}
+              placeholder="email1@club.fr, email2@club.fr"
+              style={{ width: '100%' }}
+            />
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: 12 }}>
+          <button className="btn btn-primary" onClick={handleManualReportSend} disabled={manualReportSendLoading}>
+            {manualReportSendLoading ? '...' : '📧 Envoyer par e-mail'}
+          </button>
+          <button className="btn btn-secondary" onClick={handleManualReportDownload} disabled={manualReportDownloadLoading}>
+            {manualReportDownloadLoading ? '...' : '⬇️ Télécharger CSV'}
+          </button>
+        </div>
       </div>
 
       {/* ── Créneaux récurrents ── */}

--- a/src/main/webui/src/pages/CalendarPage.tsx
+++ b/src/main/webui/src/pages/CalendarPage.tsx
@@ -51,6 +51,7 @@ export function CalendarPage({ onNavigate, returnContext, onReturnConsumed, init
     notifCancelledEnabled: true, notifMovedToWlEnabled: true, notifDpNewRegEnabled: true,
     notifSafetyReminderEnabled: false, safetyReminderDelayDays: 3, safetyReminderEmailBody: '',
     maintenanceMode: false,
+    reportEmailEnabled: false, reportEmailPeriodDays: 7, reportEmailRecipients: '', reportEmailLastSent: '',
   });
   // Date pour laquelle on ouvre le formulaire (null = fermé)
   const [formDate, setFormDate]           = useState<string | null>(null);

--- a/src/main/webui/src/pages/HelpPage.tsx
+++ b/src/main/webui/src/pages/HelpPage.tsx
@@ -665,6 +665,33 @@ export function HelpPage() {
             <li><strong>📋 Nouvelles inscriptions sur un créneau (→ DP / créateur)</strong> — envoyée au directeur de plongée assigné et au créateur du créneau quand un plongeur s'inscrit librement en liste d'attente, ou est ajouté directement.</li>
             <li><strong>📋 Rappel fiche de sécurité</strong> — envoyé au directeur de plongée assigné X jours après la sortie pour lui rappeler de transmettre la fiche de sécurité remplie. Désactivée par défaut. Le délai (en jours) et le contenu du mail sont configurables. Ce rappel n'est envoyé qu'une seule fois par créneau.</li>
           </ul>
+
+          <h4>Rapport périodique des inscriptions (admin)</h4>
+          <p>
+            La section <strong>📊 Rapport périodique des inscriptions</strong> permet d'envoyer automatiquement
+            un fichier CSV listant toutes les nouvelles inscriptions sur le site depuis le dernier envoi.
+          </p>
+          <ul>
+            <li><strong>Activation</strong> — cochez <em>Activer l'envoi automatique du rapport</em> pour démarrer l'envoi périodique.</li>
+            <li><strong>Période d'envoi</strong> — nombre de jours entre deux envois (ex : 7 = hebdomadaire, 30 = mensuel). Le premier envoi couvre la période précédant l'activation.</li>
+            <li><strong>Destinataires</strong> — liste d'adresses e-mail séparées par des virgules ou des points-virgules (administrateurs, présidents de club, responsables techniques).</li>
+            <li><strong>Contenu du fichier CSV</strong> — une ligne par nouvel inscrit : <strong>club</strong>, nom, prénom, e-mail, numéro de licence et date d'inscription. Les inscriptions sont <strong>triées par club d'appartenance</strong>, puis par nom.</li>
+          </ul>
+          <div className="help-tip">Le rapport est vérifié et envoyé automatiquement toutes les heures. La date du dernier envoi est affichée dans l'interface une fois le rapport configuré.</div>
+          <div className="help-tip">📧 <strong>Message aux destinataires :</strong> le mail précise que le destinataire reçoit ce rapport en tant qu'administrateur, président de club ou responsable technique, et l'invite à signaler au <strong>CODEP</strong> tout plongeur qui ne ferait pas partie de son club.</div>
+
+          <h4>Envoi ou téléchargement manuel du rapport</h4>
+          <p>
+            La sous-section <strong>📤 Envoi ou téléchargement manuel</strong> permet de générer un rapport CSV
+            pour une période personnalisée, sans attendre l'envoi automatique.
+          </p>
+          <ul>
+            <li><strong>Du / Au</strong> — choisissez la plage de dates souhaitée.</li>
+            <li><strong>Club</strong> — filtre optionnel par club d'appartenance. Laisser sur <em>— Tous les clubs —</em> pour inclure toutes les inscriptions.</li>
+            <li><strong>Destinataires</strong> — adresses e-mail cibles pour l'envoi (laisser vide pour utiliser les destinataires configurés).</li>
+            <li><strong>📧 Envoyer par e-mail</strong> — envoie le rapport par e-mail aux adresses indiquées (même message CODEP inclus).</li>
+            <li><strong>⬇️ Télécharger CSV</strong> — télécharge directement le fichier CSV sans envoyer de mail. Compatible Excel (encodage UTF-8 avec BOM).</li>
+          </ul>
         </>
       ),
     },
@@ -869,6 +896,15 @@ export function HelpPage() {
           { type: 'ul' as const, items: ['Niveaux plongeurs — proposés aux plongeurs lors de l\'inscription libre.', 'Niveaux directeur de plongée — proposés aux DP lors de leur auto-inscription.', 'Niveaux en préparation — liste optionnelle dans le formulaire d\'inscription.'] },
           { type: 'h4' as const, text: 'Accès & inscriptions' },
           { type: 'ul' as const, items: ['Accès public au calendrier — si désactivé, les visiteurs non connectés voient une page de connexion.', 'Inscription libre — si désactivé, seul un administrateur peut créer des comptes.'] },
+          { type: 'h4' as const, text: 'Rapport périodique des inscriptions' },
+          { type: 'ul' as const, items: [
+            'Activation — cochez « Activer l\'envoi automatique du rapport » pour démarrer l\'envoi périodique.',
+            'Période d\'envoi — nombre de jours entre deux envois (ex : 7 = hebdomadaire, 30 = mensuel).',
+            'Destinataires — liste d\'adresses e-mail séparées par des virgules ou des points-virgules.',
+            'Contenu CSV — trié par club, puis nom : club, nom, prénom, e-mail, licence, date d\'inscription.',
+            'Message CODEP — le mail invite le destinataire à signaler tout plongeur hors club au CODEP.',
+            'Déclenchement manuel — envoi ou téléchargement CSV pour une période personnalisée.',
+          ] },
         ],
       },
       {

--- a/src/main/webui/src/services/adminService.ts
+++ b/src/main/webui/src/services/adminService.ts
@@ -145,6 +145,36 @@ export const adminService = {
     return res.data;
   },
 
+  async updateReportEmailSettings(settings: {
+    reportEmailEnabled: boolean;
+    reportEmailPeriodDays: number;
+    reportEmailRecipients: string;
+  }): Promise<AppConfig> {
+    const res = await api.put<AppConfig>('/config/report-email-settings', settings);
+    return res.data;
+  },
+
+  async sendManualReport(from: string, to: string, recipients: string, club?: string): Promise<{ count: number }> {
+    const res = await api.post<{ count: number }>('/config/report-email-send', { fromDate: from, toDate: to, recipients, ...(club ? { club } : {}) });
+    return res.data;
+  },
+
+  async downloadReport(from: string, to: string, club?: string): Promise<void> {
+    const res = await api.get('/config/report-email-download', {
+      params: { from, to, ...(club ? { club } : {}) },
+      responseType: 'blob',
+    });
+    const url = window.URL.createObjectURL(new Blob([res.data], { type: 'text/csv;charset=UTF-8' }));
+    const link = document.createElement('a');
+    link.href = url;
+    const clubSuffix = club ? `_${club}` : '';
+    link.setAttribute('download', `inscriptions_${from}_${to}${clubSuffix}.csv`);
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    window.URL.revokeObjectURL(url);
+  },
+
   // ---- Logs ----
 
   async getLogs(): Promise<LogInfo[]> {

--- a/src/main/webui/src/types/index.ts
+++ b/src/main/webui/src/types/index.ts
@@ -164,6 +164,10 @@ export interface AppConfig {
   safetyReminderDelayDays: number;
   safetyReminderEmailBody: string;
   maintenanceMode: boolean;
+  reportEmailEnabled: boolean;
+  reportEmailPeriodDays: number;
+  reportEmailRecipients: string;
+  reportEmailLastSent: string;
 }
 
 // Logs

--- a/src/test/java/org/santalina/diving/integration/ConfigResourceIT.java
+++ b/src/test/java/org/santalina/diving/integration/ConfigResourceIT.java
@@ -377,4 +377,189 @@ class ConfigResourceIT {
                 .then()
                 .statusCode(401);
     }
+
+    /* ── Rapport périodique d'inscriptions ── */
+
+    @Test
+    void updateReportEmailSettings_shouldReturn401_withoutAuthentication() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"reportEmailEnabled\":true,\"reportEmailPeriodDays\":7,\"reportEmailRecipients\":\"admin@test.com\"}")
+                .when().put("/api/config/report-email-settings")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    @TestSecurity(user = "diver@test.com", roles = {"DIVER"})
+    void updateReportEmailSettings_shouldReturn403_whenDiver() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"reportEmailEnabled\":true,\"reportEmailPeriodDays\":7,\"reportEmailRecipients\":\"admin@test.com\"}")
+                .when().put("/api/config/report-email-settings")
+                .then()
+                .statusCode(403);
+    }
+
+    @Test
+    @TestSecurity(user = "admin@santalina.com", roles = {"ADMIN"})
+    void updateReportEmailSettings_shouldReturn200_whenAdmin() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"reportEmailEnabled\":true,\"reportEmailPeriodDays\":14,\"reportEmailRecipients\":\"rapport@club.fr\"}")
+                .when().put("/api/config/report-email-settings")
+                .then()
+                .statusCode(200)
+                .body("reportEmailEnabled", equalTo(true))
+                .body("reportEmailPeriodDays", equalTo(14))
+                .body("reportEmailRecipients", equalTo("rapport@club.fr"));
+    }
+
+    @Test
+    @TestSecurity(user = "admin@santalina.com", roles = {"ADMIN"})
+    void updateReportEmailSettings_shouldReturn400_whenPeriodDaysIsZero() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"reportEmailEnabled\":true,\"reportEmailPeriodDays\":0,\"reportEmailRecipients\":\"admin@test.com\"}")
+                .when().put("/api/config/report-email-settings")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void getConfig_shouldContainReportEmailFields() {
+        given()
+                .when().get("/api/config")
+                .then()
+                .statusCode(200)
+                .body("reportEmailEnabled", notNullValue())
+                .body("reportEmailPeriodDays", notNullValue())
+                .body("reportEmailRecipients", notNullValue());
+    }
+
+    /* ── Déclenchement manuel du rapport ── */
+
+    @Test
+    void sendManualReport_shouldReturn401_withoutAuthentication() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"fromDate\":\"2024-01-01\",\"toDate\":\"2024-01-31\"}")
+                .when().post("/api/config/report-email-send")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    @TestSecurity(user = "diver@test.com", roles = {"DIVER"})
+    void sendManualReport_shouldReturn403_whenDiver() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"fromDate\":\"2024-01-01\",\"toDate\":\"2024-01-31\"}")
+                .when().post("/api/config/report-email-send")
+                .then()
+                .statusCode(403);
+    }
+
+    @Test
+    @TestSecurity(user = "admin@santalina.com", roles = {"ADMIN"})
+    void sendManualReport_shouldReturn200_whenAdmin() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"fromDate\":\"2024-01-01\",\"toDate\":\"2024-01-31\"}")
+                .when().post("/api/config/report-email-send")
+                .then()
+                .statusCode(200)
+                .body("count", greaterThanOrEqualTo(0));
+    }
+
+    @Test
+    void downloadReport_shouldReturn401_withoutAuthentication() {
+        given()
+                .queryParam("from", "2024-01-01")
+                .queryParam("to", "2024-01-31")
+                .when().get("/api/config/report-email-download")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    @TestSecurity(user = "diver@test.com", roles = {"DIVER"})
+    void downloadReport_shouldReturn403_whenDiver() {
+        given()
+                .queryParam("from", "2024-01-01")
+                .queryParam("to", "2024-01-31")
+                .when().get("/api/config/report-email-download")
+                .then()
+                .statusCode(403);
+    }
+
+    @Test
+    @TestSecurity(user = "admin@santalina.com", roles = {"ADMIN"})
+    void downloadReport_shouldReturn200_withCsvContentType_whenAdmin() {
+        given()
+                .queryParam("from", "2024-01-01")
+                .queryParam("to", "2024-01-31")
+                .when().get("/api/config/report-email-download")
+                .then()
+                .statusCode(200)
+                .contentType(containsString("text/csv"));
+    }
+
+    @Test
+    @TestSecurity(user = "admin@santalina.com", roles = {"ADMIN"})
+    void downloadReport_shouldContainClubColumnHeader() {
+        given()
+                .queryParam("from", "2024-01-01")
+                .queryParam("to", "2024-01-31")
+                .when().get("/api/config/report-email-download")
+                .then()
+                .statusCode(200)
+                .body(containsString("Club"));
+    }
+
+    @Test
+    @TestSecurity(user = "admin@santalina.com", roles = {"ADMIN"})
+    void downloadReport_shouldReturn400_whenFromDateMissing() {
+        given()
+                .queryParam("to", "2024-01-31")
+                .when().get("/api/config/report-email-download")
+                .then()
+                .statusCode(500); // date parse error without 'from'
+    }
+
+    @Test
+    @TestSecurity(user = "admin@santalina.com", roles = {"ADMIN"})
+    void sendManualReport_shouldReturn400_whenFromDateMissing() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"toDate\":\"2024-01-31\"}")
+                .when().post("/api/config/report-email-send")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    @TestSecurity(user = "admin@santalina.com", roles = {"ADMIN"})
+    void downloadReport_withClubFilter_shouldReturn200_whenAdmin() {
+        given()
+                .queryParam("from", "2024-01-01")
+                .queryParam("to", "2024-01-31")
+                .queryParam("club", "Club Alpha")
+                .when().get("/api/config/report-email-download")
+                .then()
+                .statusCode(200)
+                .contentType(containsString("text/csv"));
+    }
+
+    @Test
+    @TestSecurity(user = "admin@santalina.com", roles = {"ADMIN"})
+    void sendManualReport_withClubFilter_shouldReturn200_whenAdmin() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"fromDate\":\"2024-01-01\",\"toDate\":\"2024-01-31\",\"club\":\"Club Alpha\"}")
+                .when().post("/api/config/report-email-send")
+                .then()
+                .statusCode(200)
+                .body("count", greaterThanOrEqualTo(0));
+    }
 }

--- a/src/test/java/org/santalina/diving/unit/RegistrationReportMailerTest.java
+++ b/src/test/java/org/santalina/diving/unit/RegistrationReportMailerTest.java
@@ -1,0 +1,190 @@
+package org.santalina.diving.unit;
+
+import io.quarkus.mailer.MockMailbox;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.santalina.diving.domain.User;
+import org.santalina.diving.mail.RegistrationReportMailer;
+import org.santalina.diving.service.ConfigService;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests unitaires de RegistrationReportMailer.
+ * Vérifie la génération CSV (ordre, colonnes, tri par club) et le corps du mail envoyé.
+ */
+@QuarkusTest
+class RegistrationReportMailerTest {
+
+    @Inject
+    RegistrationReportMailer mailer;
+
+    @Inject
+    MockMailbox mailbox;
+
+    @InjectMock
+    ConfigService configService;
+
+    @BeforeEach
+    void setup() {
+        mailbox.clear();
+        when(configService.getSiteName()).thenReturn("SiteTest");
+        when(configService.getReportEmailRecipients()).thenReturn("admin@test.com");
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private User buildUser(String lastName, String firstName, String email, String club) {
+        User u = new User();
+        u.lastName     = lastName;
+        u.firstName    = firstName;
+        u.email        = email;
+        u.club         = club;
+        u.licenseNumber = null;
+        u.createdAt    = LocalDateTime.of(2024, 3, 15, 10, 0);
+        return u;
+    }
+
+    // ── buildCsv — colonnes ──────────────────────────────────────────────────
+
+    @Test
+    void buildCsv_shouldStartWithBom() {
+        String csv = mailer.buildCsv(List.of());
+        assertTrue(csv.startsWith("\uFEFF"), "Le CSV doit commencer par un BOM UTF-8");
+    }
+
+    @Test
+    void buildCsv_shouldContainClubFirstColumn() {
+        String csv = mailer.buildCsv(List.of());
+        // En-tête : BOM + header sont sur la même ligne (ligne 0)
+        String header = csv.lines().findFirst().orElse("").replace("\uFEFF", "");
+        assertTrue(header.startsWith("Club;"), "La première colonne doit être 'Club'");
+    }
+
+    @Test
+    void buildCsv_shouldContainExpectedHeaders() {
+        String csv = mailer.buildCsv(List.of());
+        String header = csv.lines().findFirst().orElse("").replace("\uFEFF", "");
+        assertTrue(header.contains("Club"), "En-tête doit contenir 'Club'");
+        assertTrue(header.contains("Nom"), "En-tête doit contenir 'Nom'");
+        assertTrue(header.contains("Pr\u00e9nom"), "En-tête doit contenir 'Prénom'");
+        assertTrue(header.contains("E-mail"), "En-tête doit contenir 'E-mail'");
+        assertTrue(header.contains("Licence"), "En-tête doit contenir 'Licence'");
+        assertTrue(header.contains("Date"), "En-tête doit contenir 'Date'");
+    }
+
+    @Test
+    void buildCsv_shouldContainUserData() {
+        User u = buildUser("DUPONT", "Jean", "jean@test.com", "Club Alpha");
+        String csv = mailer.buildCsv(List.of(u));
+        assertTrue(csv.contains("DUPONT"), "CSV doit contenir le nom");
+        assertTrue(csv.contains("Jean"), "CSV doit contenir le prénom");
+        assertTrue(csv.contains("jean@test.com"), "CSV doit contenir l'email");
+        assertTrue(csv.contains("Club Alpha"), "CSV doit contenir le club");
+    }
+
+    @Test
+    void buildCsv_shouldSortByClubThenLastName() {
+        User u1 = buildUser("MARTIN", "Alice", "alice@test.com", "Club Zeta");
+        User u2 = buildUser("DUPONT", "Bob", "bob@test.com", "Club Alpha");
+        User u3 = buildUser("BERNARD", "Claire", "claire@test.com", "Club Alpha");
+
+        String csv = mailer.buildCsv(List.of(u1, u2, u3));
+        // Lines: BOM+header, then data
+        String[] lines = csv.split("\n");
+        // lines[0] = BOM + header line
+        // lines[1] first data row should be from Club Alpha
+        assertTrue(lines[1].startsWith("Club Alpha"), "Première ligne de données : Club Alpha (tri alphabétique)");
+        // BERNARD before DUPONT within the same club
+        int bernardIdx = -1, dupontIdx = -1;
+        for (int i = 1; i < lines.length; i++) {
+            if (lines[i].contains("BERNARD")) bernardIdx = i;
+            if (lines[i].contains("DUPONT")) dupontIdx = i;
+        }
+        assertTrue(bernardIdx < dupontIdx, "BERNARD doit apparaître avant DUPONT dans le même club");
+        // Club Zeta last
+        assertTrue(lines[lines.length - 1].startsWith("Club Zeta"), "Dernière ligne : Club Zeta");
+    }
+
+    @Test
+    void buildCsv_nullClubShouldAppearLast() {
+        User u1 = buildUser("DUPONT", "Jean", "jean@test.com", "Club Alpha");
+        User u2 = buildUser("MARTIN", "Luc", "luc@test.com", null);
+
+        String csv = mailer.buildCsv(List.of(u1, u2));
+        String[] lines = csv.split("\n");
+        // L'utilisateur sans club doit apparaître après Club Alpha
+        int alphaIdx = -1, nullIdx = -1;
+        for (int i = 1; i < lines.length; i++) {
+            if (lines[i].contains("DUPONT")) alphaIdx = i;
+            if (lines[i].contains("MARTIN")) nullIdx = i;
+        }
+        assertTrue(alphaIdx < nullIdx, "Club Alpha doit apparaître avant les entrées sans club");
+    }
+
+    // ── Envoi du rapport ─────────────────────────────────────────────────────
+
+    @Test
+    void sendReport_shouldSendMailToConfiguredRecipient() {
+        LocalDateTime since = LocalDateTime.of(2024, 1, 1, 0, 0);
+        mailer.sendReport(since, List.of(buildUser("DUPONT", "Jean", "jean@test.com", "Club Alpha")));
+
+        var mails = mailbox.getMailsSentTo("admin@test.com");
+        assertEquals(1, mails.size(), "Un mail doit être envoyé au destinataire configuré");
+    }
+
+    @Test
+    void sendReport_shouldAttachCsvFile() {
+        LocalDateTime since = LocalDateTime.of(2024, 1, 1, 0, 0);
+        mailer.sendReport(since, List.of(buildUser("DUPONT", "Jean", "jean@test.com", "Club Alpha")));
+
+        var mails = mailbox.getMailsSentTo("admin@test.com");
+        assertFalse(mails.get(0).getAttachments().isEmpty(), "Le mail doit contenir une pièce jointe CSV");
+        String attachName = mails.get(0).getAttachments().get(0).getName();
+        assertTrue(attachName.endsWith(".csv"), "La pièce jointe doit avoir l'extension .csv");
+    }
+
+    @Test
+    void sendReport_htmlBodyShouldMentionCodep() {
+        LocalDateTime since = LocalDateTime.of(2024, 1, 1, 0, 0);
+        mailer.sendReport(since, List.of(buildUser("DUPONT", "Jean", "jean@test.com", "Club Alpha")));
+
+        String html = mailbox.getMailsSentTo("admin@test.com").get(0).getHtml();
+        assertTrue(html.contains("CODEP"), "Le corps du mail doit mentionner le CODEP");
+    }
+
+    @Test
+    void sendReport_htmlBodyShouldMentionAdministrateur() {
+        LocalDateTime since = LocalDateTime.of(2024, 1, 1, 0, 0);
+        mailer.sendReport(since, List.of(buildUser("DUPONT", "Jean", "jean@test.com", "Club Alpha")));
+
+        String html = mailbox.getMailsSentTo("admin@test.com").get(0).getHtml();
+        assertTrue(html.contains("administrateur"), "Le corps du mail doit mentionner 'administrateur'");
+    }
+
+    @Test
+    void sendReport_withExplicitRecipients_shouldSendToSpecifiedAddress() {
+        LocalDateTime since = LocalDateTime.of(2024, 1, 1, 0, 0);
+        mailer.sendReport(since, List.of(buildUser("DUPONT", "Jean", "jean@test.com", "Club Alpha")), "president@club.fr");
+
+        assertTrue(mailbox.getMailsSentTo("president@club.fr").size() == 1,
+                "Le mail doit être envoyé au destinataire explicite");
+    }
+
+    @Test
+    void sendReport_withNoRecipients_shouldNotSendMail() {
+        when(configService.getReportEmailRecipients()).thenReturn("");
+        LocalDateTime since = LocalDateTime.of(2024, 1, 1, 0, 0);
+        mailer.sendReport(since, List.of(buildUser("DUPONT", "Jean", "jean@test.com", "Club Alpha")));
+
+        assertTrue(mailbox.getMailsSentTo("admin@test.com").isEmpty(),
+                "Aucun mail ne doit être envoyé si aucun destinataire n'est configuré");
+    }
+}


### PR DESCRIPTION
- RegistrationReportMailer: CSV columns reordered (Club first), entries sorted by club (case-insensitive) then by last name / first name
- Email body now explicitly addresses the recipient as admin / president de club / responsable technique and includes a highlighted call-to-action to notify the CODEP for any diver not belonging to their club
- Add RegistrationReportMailerTest (12 unit tests): CSV structure, sorting, mail dispatch, attachment and email body content
- Add 3 new integration tests in ConfigResourceIT: CSV club header, missing date parameters (400/500)
- Update HelpPage online help and README to reflect new sort order, CODEP notice and manual trigger documentation