### PR TITLE
feat(mail): ajout du mail d'organisation pour les directeurs de plongée

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Application de réservation de créneaux de plongée en lac, développée avec *
 - **Liste d'attente** : inscription libre, validation/refus par le DP responsable
 - **Inscriptions libres** : le DP assigné peut ouvrir les inscriptions avec date d'ouverture optionnelle
 - **Organisation des palanquées** : drag-and-drop, gestion des aptitudes, export Excel fiche de sécurité, export CSV
+- **Mail d'organisation** (DIVE_DIRECTOR) : envoi groupé depuis la page Palanquées — plongeurs en BCC, DP en CC, Reply-To = DP ; éditeur WYSIWYG avec variables `{siteName}`, `{slotDate}`, `{dpName}`… ; modèle personnalisable par DP dans son profil
 - **Normalisation des données** : prénoms capitalisés, emails en minuscules
 - **Docker-ready** : Dockerfile multi-stage + docker-compose
 - **Double base de données** : H2 fichier (dev) / PostgreSQL (prod)
@@ -121,8 +122,10 @@ docker compose up --build
 | `POST` | `/api/slots/{id}/palanquees` | ADMIN, DIVE_DIRECTOR | Créer une palanquée |
 | `PUT` | `/api/slots/{id}/palanquees/{pid}` | ADMIN, DIVE_DIRECTOR | Modifier une palanquée |
 | `DELETE` | `/api/slots/{id}/palanquees/{pid}` | ADMIN, DIVE_DIRECTOR | Supprimer une palanquée |
+| `POST` | `/api/slots/{id}/mail/organization` | ADMIN, DIVE_DIRECTOR | Envoyer le mail d'organisation aux plongeurs |
 | `GET` | `/api/users/me` | Authentifié | Mon profil |
 | `PUT` | `/api/users/me` | Authentifié | Modifier profil |
+| `PUT` | `/api/users/me/dp-email-template` | ADMIN, DIVE_DIRECTOR | Enregistrer le modèle d'email DP |
 | `GET` | `/api/users` | ADMIN | Liste utilisateurs |
 | `PUT` | `/api/users/{id}/roles` | ADMIN | Changer rôles |
 | `GET` | `/api/config` | Public | Config du site |
@@ -213,7 +216,7 @@ src/main/
 │   ├── domain/          # Entités JPA (User, DiveSlot, SlotDiver, WaitingListEntry, Palanquee, AppConfigEntry)
 │   ├── dto/             # Records Java (request/response)
 │   ├── exception/       # GlobalExceptionMapper
-│   ├── mail/            # PasswordResetMailer, ActivationMailer, WaitingListMailer, RegistrationReportMailer
+│   ├── mail/            # PasswordResetMailer, ActivationMailer, WaitingListMailer, RegistrationReportMailer, DpOrganizerMailer
 │   ├── resource/        # JAX-RS endpoints (AuthResource, SlotResource, SlotDiverResource,
 │   │                   #   WaitingListResource, PalanqueeResource, UserResource, StatsResource, BackupResource…)
 │   ├── scheduler/       # RegistrationReportScheduler (rapport périodique inscriptions)

--- a/src/main/java/org/santalina/diving/domain/User.java
+++ b/src/main/java/org/santalina/diving/domain/User.java
@@ -105,6 +105,10 @@ public class User extends PanacheEntityBase {
     @Column(name = "club_certified", nullable = false)
     public boolean clubCertified = false;
 
+    /** Modèle de mail d'organisation stocké par le directeur de plongée dans son profil */
+    @Column(name = "dp_organizer_email_template", columnDefinition = "TEXT")
+    public String dpOrganizerEmailTemplate;
+
     // ---- helpers ----
 
     /** Retourne le nom complet (prénom + nom). */

--- a/src/main/java/org/santalina/diving/dto/BackupDto.java
+++ b/src/main/java/org/santalina/diving/dto/BackupDto.java
@@ -46,7 +46,8 @@ public class BackupDto {
             boolean notifOnDpRegistration,
             boolean notifOnCreatorRegistration,
             boolean notifOnSafetyReminder,
-            boolean clubCertified
+            boolean clubCertified,
+            String dpOrganizerEmailTemplate
     ) {}
 
     public record SlotEntry(

--- a/src/main/java/org/santalina/diving/dto/UserDto.java
+++ b/src/main/java/org/santalina/diving/dto/UserDto.java
@@ -25,7 +25,8 @@ public class UserDto {
             boolean notifOnMovedToWaitlist,
             boolean notifOnDpRegistration,
             boolean notifOnCreatorRegistration,
-            boolean notifOnSafetyReminder
+            boolean notifOnSafetyReminder,
+            String dpOrganizerEmailTemplate
     ) {
         public static UserResponse from(User user) {
             return new UserResponse(
@@ -39,7 +40,8 @@ public class UserDto {
                     user.notifOnMovedToWaitlist,
                     user.notifOnDpRegistration,
                     user.notifOnCreatorRegistration,
-                    user.notifOnSafetyReminder
+                    user.notifOnSafetyReminder,
+                    user.dpOrganizerEmailTemplate
             );
         }
     }
@@ -132,5 +134,10 @@ public class UserDto {
             @jakarta.validation.constraints.NotBlank String csvContent,
             @jakarta.validation.constraints.NotBlank
             @jakarta.validation.constraints.Size(min = 6, max = 100) String password
+    ) {}
+
+    /** Mise à jour du modèle d'email d'organisation du directeur de plongée. */
+    public record UpdateDpEmailTemplateRequest(
+            String template
     ) {}
 }

--- a/src/main/java/org/santalina/diving/mail/DpOrganizerMailer.java
+++ b/src/main/java/org/santalina/diving/mail/DpOrganizerMailer.java
@@ -1,0 +1,202 @@
+package org.santalina.diving.mail;
+
+import io.quarkus.mailer.Mail;
+import io.quarkus.mailer.Mailer;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+import org.santalina.diving.domain.DiveSlot;
+import org.santalina.diving.domain.SlotDiver;
+import org.santalina.diving.domain.User;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Mailer pour l'envoi du mail d'organisation de sortie par le directeur de plongée.
+ * <p>
+ * La liste des plongeurs est en CCI (BCC), le DP est en CC, le Reply-To pointe vers le DP.
+ * </p>
+ */
+@ApplicationScoped
+public class DpOrganizerMailer {
+
+    private static final Logger LOG = Logger.getLogger(DpOrganizerMailer.class);
+
+    /** Modèle par défaut variabilisé fourni à tout nouveau DP. */
+    public static final String DEFAULT_TEMPLATE =
+        "<p>Bonjour à tous,</p>" +
+        "<p>Vous êtes inscrits à la sortie du <strong>{slotDate}</strong> à la {siteName} " +
+        "(RDV à la {siteName} à {startTime}).</p>" +
+        "<p>Voici quelques informations utiles à l'organisation de cette plongée.</p>" +
+        "<h3>Horaires</h3>" +
+        "<ul>" +
+        "<li>Récupérez le matériel dans votre club, 1 bloc pour chaque plongée.</li>" +
+        "<li>Pour ceux qui ont déjà tout le matériel, rendez-vous directement à la {siteName} à {startTime}. " +
+        "Dans ce cas merci de me prévenir.</li>" +
+        "<li>Prévoyez de quoi pique-niquer sur place après la plongée et de vous hydrater " +
+        "(1 bouteille d'eau ou gourde par personne).</li>" +
+        "</ul>" +
+        "<h3>Administratif</h3>" +
+        "<ul>" +
+        "<li>Pensez à prendre les papiers nécessaires à la plongée :<br/>" +
+        "Certificat médical, Carte de niveau, Carnet de plongée, Licence</li>" +
+        "</ul>" +
+        "<p><strong>==&gt; Pas de papiers = Pas de plongée</strong></p>" +
+        "<ul>" +
+        "<li>Prenez également vos fiches de progression et de suivi.</li>" +
+        "<li>Pensez à contrôler vos papiers avant samedi matin ! Licence active et CACI valide !</li>" +
+        "</ul>" +
+        "<h3>Météo</h3>" +
+        "<p>Pensez à prendre des vêtements chauds pour couvrir entre les 2 plongées.</p>" +
+        "<p>La température de l'eau peut être inférieure à 10 °C au-delà de 3 m. " +
+        "Prévoyez une combinaison adaptée, des gants, des chaussons et une cagoule. " +
+        "Pensez également à prendre vos plombs !</p>" +
+        "<h3>Règles de vie à la {siteName}</h3>" +
+        "<ul>" +
+        "<li>Les véhicules doivent être stationnés sur les emplacements prévus à cet effet. " +
+        "Attention ! ne pas se garer sur la pelouse des locataires.</li>" +
+        "<li>Au niveau du plan d'eau, aucun véhicule ne doit stationner. " +
+        "On peut décharger/charger son matériel, puis se garer sur le parking au niveau du local.</li>" +
+        "<li>Pour le pique-nique, nous le prendrons dans le local pour ne pas avoir froid.</li>" +
+        "</ul>" +
+        "<h3>Rappel sur le règlement spécifique de la {siteName}</h3>" +
+        "<ul>" +
+        "<li>Espace médian 6-20 m : chaque plongeur au-delà de 20 m doit être équipé de 2 premiers étages " +
+        "et d'une lampe flash.</li>" +
+        "<li>Espace lointain +20 m : le guide de palanquée doit avoir une source de lumière " +
+        "(autre que la lampe flash).</li>" +
+        "</ul>" +
+        "<p>La présence d'un parachute de palier par palanquée (pour les encadrants) est obligatoire " +
+        "(Code du sport).</p>" +
+        "<p>En cas de contre-temps ou de retard, merci de me prévenir au plus tôt par mail ou téléphone " +
+        "afin que je puisse ajuster mon organisation.</p>" +
+        "<p>({dpPhone} ou {dpEmail}).</p>" +
+        "<p>Je reste à votre disposition pour toutes questions complémentaires.</p>" +
+        "<p>Bonne fin de semaine à tous et à bientôt,</p>" +
+        "<p><strong>{dpName}</strong><br/>{dpPhone}</p>";
+
+    @Inject
+    Mailer mailer;
+
+    /**
+     * Envoie le mail d'organisation aux plongeurs du créneau.
+     *
+     * @param slot           Créneau concerné
+     * @param dp             Directeur de plongée qui envoie le mail
+     * @param divers         Liste des plongeurs inscrits
+     * @param emailOverrides Emails saisis manuellement pour les plongeurs sans adresse (diverId → email)
+     * @param subject        Objet du mail (peut contenir des variables)
+     * @param htmlBody       Corps HTML du mail (peut contenir des variables)
+     * @param siteName       Nom du site (pour la résolution des variables)
+     */
+    public void sendOrganizationEmail(DiveSlot slot, User dp, List<SlotDiver> divers,
+                                      Map<Long, String> emailOverrides,
+                                      String subject, String htmlBody, String siteName) {
+
+        String resolvedSubject = resolveVariables(subject, slot, dp, siteName);
+        String resolvedBody    = resolveVariables(htmlBody, slot, dp, siteName);
+        String wrappedBody     = wrapHtml(resolvedBody, siteName);
+
+        String dpEmail = dp != null && dp.email != null && !dp.email.isBlank() ? dp.email.trim() : null;
+
+        // Collecter les adresses uniques des plongeurs
+        List<String> recipients = divers.stream()
+                .map(d -> {
+                    if (d.email != null && !d.email.isBlank()) return d.email.trim();
+                    if (emailOverrides != null) {
+                        String ov = emailOverrides.get(d.id);
+                        return (ov != null && !ov.isBlank()) ? ov.trim() : null;
+                    }
+                    return null;
+                })
+                .filter(e -> e != null && !e.isBlank())
+                .distinct()
+                .toList();
+
+        if (recipients.isEmpty()) {
+            LOG.warnf("Mail d'organisation (slotId=%d) : aucune adresse mail de plongeur disponible, envoi annulé.", slot.id);
+            return;
+        }
+
+        // Envoyer un mail individuel par plongeur (visible séparément dans MailHog
+        // et mieux accepté par les filtres anti-spam que le BCC massif).
+        List<Mail> mails = new java.util.ArrayList<>();
+        for (String to : recipients) {
+            Mail m = Mail.withHtml(to, resolvedSubject, wrappedBody);
+            if (dpEmail != null) {
+                m.addHeader("Reply-To", dpEmail);
+            }
+            mails.add(m);
+        }
+
+        // Copie au DP avec la liste des destinataires en bas
+        if (dpEmail != null) {
+            StringBuilder recipientList = new StringBuilder(
+                    "<hr style=\"border:1px solid #e5e7eb;margin-top:24px;\"/>\n"
+                    + "<p style=\"color:#374151;font-size:13px;\"><strong>Ce mail a été envoyé aux adresses suivantes :</strong></p>\n"
+                    + "<ul style=\"font-size:13px;color:#6b7280;\">\n");
+            for (String r : recipients) {
+                recipientList.append("  <li>").append(r).append("</li>\n");
+            }
+            recipientList.append("</ul>\n");
+            String copyBody = wrapHtml(resolvedBody + recipientList, siteName);
+            mails.add(Mail.withHtml(dpEmail, "[Copie] " + resolvedSubject, copyBody));
+        }
+
+        mailer.send(mails.toArray(new Mail[0]));
+        LOG.infof("Mail d'organisation envoyé pour slotId=%d par %s — %d destinataire(s).",
+                slot.id, dpEmail, recipients.size());
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Remplace les variables dans une chaîne de caractères.
+     * Variables disponibles : {siteName}, {slotDate}, {startTime}, {endTime},
+     *                         {slotTitle}, {dpName}, {dpEmail}, {dpPhone}
+     */
+    public static String resolveVariables(String template, DiveSlot slot, User dp, String siteName) {
+        if (template == null) return "";
+
+        // Date formatée "jeudi 12 avril 2026"
+        String slotDate = slot.slotDate.format(
+                DateTimeFormatter.ofPattern("EEEE d MMMM yyyy", Locale.FRENCH));
+
+        // Heures "09h15"
+        String startTime = String.format("%02dh%02d",
+                slot.startTime.getHour(), slot.startTime.getMinute());
+        String endTime = String.format("%02dh%02d",
+                slot.endTime.getHour(), slot.endTime.getMinute());
+
+        String slotTitle = slot.title != null ? slot.title : "";
+        String dpName    = dp != null ? dp.fullName() : "";
+        String dpEmail   = dp != null && dp.email != null ? dp.email : "";
+        String dpPhone   = dp != null && dp.phone != null ? dp.phone : "";
+
+        return template
+                .replace("{siteName}",  siteName != null ? siteName : "")
+                .replace("{slotDate}",  slotDate)
+                .replace("{startTime}", startTime)
+                .replace("{endTime}",   endTime)
+                .replace("{slotTitle}", slotTitle)
+                .replace("{dpName}",    dpName)
+                .replace("{dpEmail}",   dpEmail)
+                .replace("{dpPhone}",   dpPhone);
+    }
+
+    private static String wrapHtml(String body, String siteName) {
+        return "<!DOCTYPE html>\n<html lang=\"fr\">\n<head>\n"
+                + "  <meta charset=\"UTF-8\" />\n"
+                + "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" />\n"
+                + "</head>\n<body style=\"font-family:Arial,sans-serif;max-width:700px;margin:0 auto;\">\n"
+                + body
+                + "\n<hr style=\"border:1px solid #e5e7eb;margin-top:30px;\"/>\n"
+                + "<p style=\"color:#6b7280;font-size:12px;\">Système de réservation — " + siteName + "</p>\n"
+                + "</body></html>";
+    }
+}

--- a/src/main/java/org/santalina/diving/resource/SlotMailResource.java
+++ b/src/main/java/org/santalina/diving/resource/SlotMailResource.java
@@ -1,0 +1,146 @@
+package org.santalina.diving.resource;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.santalina.diving.domain.DiveSlot;
+import org.santalina.diving.domain.SlotDiver;
+import org.santalina.diving.domain.User;
+import org.santalina.diving.mail.DpOrganizerMailer;
+import org.santalina.diving.service.ConfigService;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Endpoint pour l'envoi du mail d'organisation du directeur de plongée.
+ * POST /api/slots/{slotId}/mail/organization
+ */
+@Path("/api/slots/{slotId}/mail")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@RolesAllowed({"ADMIN", "DIVE_DIRECTOR"})
+@Tag(name = "Mail de sortie")
+public class SlotMailResource {
+
+    @Inject
+    JsonWebToken jwt;
+
+    @Inject
+    DpOrganizerMailer dpOrganizerMailer;
+
+    @Inject
+    ConfigService configService;
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // DTO interne
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public record SendOrganizationMailRequest(
+            String subject,
+            String htmlBody,
+            Map<Long, String> emailOverrides
+    ) {}
+
+    public record MissingEmailInfo(Long diverId, String diverName) {}
+
+    public record OrganizationMailResponse(int sent, List<MissingEmailInfo> missingEmails) {}
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Endpoint
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * POST /api/slots/{slotId}/mail/organization
+     * <p>
+     * Envoie le mail d'organisation aux plongeurs inscrits sur le créneau.
+     * Retourne 422 si des plongeurs n'ont pas d'adresse mail et qu'aucun override n'est fourni.
+     * </p>
+     */
+    @POST
+    @Path("/organization")
+    @Transactional
+    public Response sendOrganizationMail(@PathParam("slotId") Long slotId,
+                                         SendOrganizationMailRequest request) {
+        if (request == null || request.htmlBody() == null || request.htmlBody().isBlank()) {
+            throw new BadRequestException("Le corps du mail est obligatoire");
+        }
+        if (request.subject() == null || request.subject().isBlank()) {
+            throw new BadRequestException("L'objet du mail est obligatoire");
+        }
+
+        DiveSlot slot = checkSlotAccess(slotId);
+        User dp       = User.findByEmail(jwt.getName());
+        List<SlotDiver> divers = SlotDiver.findBySlot(slotId);
+
+        Map<Long, String> overrides = request.emailOverrides() != null ? request.emailOverrides() : Map.of();
+
+        // Valider le format des emails saisis manuellement
+        java.util.regex.Pattern emailPattern = java.util.regex.Pattern.compile(
+                "^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$");
+        for (Map.Entry<Long, String> entry : overrides.entrySet()) {
+            String email = entry.getValue();
+            if (email != null && !email.isBlank() && !emailPattern.matcher(email.trim()).matches()) {
+                throw new BadRequestException("Format d'email invalide : " + email.trim());
+            }
+        }
+
+        // Vérifier les emails manquants
+        List<MissingEmailInfo> missing = new ArrayList<>();
+        for (SlotDiver d : divers) {
+            boolean hasEmail = (d.email != null && !d.email.isBlank())
+                    || (overrides.containsKey(d.id) && !overrides.get(d.id).isBlank());
+            if (!hasEmail) {
+                missing.add(new MissingEmailInfo(d.id, d.firstName + " " + d.lastName));
+            }
+        }
+
+        if (!missing.isEmpty()) {
+            return Response.status(422)
+                    .entity(new OrganizationMailResponse(0, missing))
+                    .build();
+        }
+
+        String siteName = configService.getSiteName();
+        dpOrganizerMailer.sendOrganizationEmail(slot, dp, divers, overrides,
+                request.subject(), request.htmlBody(), siteName);
+
+        // Compter les destinataires effectifs (emails uniques)
+        long sent = divers.stream()
+                .map(d -> (d.email != null && !d.email.isBlank()) ? d.email.trim()
+                        : overrides.getOrDefault(d.id, ""))
+                .filter(e -> !e.isBlank())
+                .distinct()
+                .count();
+
+        return Response.ok(new OrganizationMailResponse((int) sent, List.of())).build();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private DiveSlot checkSlotAccess(Long slotId) {
+        DiveSlot slot = DiveSlot.findById(slotId);
+        if (slot == null) throw new NotFoundException("Créneau non trouvé");
+
+        String role = jwt.getGroups() != null && jwt.getGroups().contains("ADMIN")
+                ? "ADMIN" : "DIVE_DIRECTOR";
+
+        if ("DIVE_DIRECTOR".equals(role)) {
+            User me = User.findByEmail(jwt.getName());
+            boolean isCreator    = me != null && slot.createdBy != null && slot.createdBy.id.equals(me.id);
+            boolean isAssignedDP = me != null && SlotDiver.isAssignedDirectorByEmail(slot.id, me.email);
+            if (!isCreator && !isAssignedDP) {
+                throw new ForbiddenException("Accès réservé au créateur ou directeur de plongée du créneau");
+            }
+        }
+        return slot;
+    }
+}

--- a/src/main/java/org/santalina/diving/resource/UserResource.java
+++ b/src/main/java/org/santalina/diving/resource/UserResource.java
@@ -107,6 +107,13 @@ public class UserResource {
         return userService.updateNotifPrefs(identity.getPrincipal().getName(), request);
     }
 
+    @PUT
+    @Path("/me/dp-email-template")
+    @RolesAllowed({"DIVE_DIRECTOR", "ADMIN"})
+    public UserResponse updateDpEmailTemplate(UpdateDpEmailTemplateRequest request) {
+        return userService.updateDpEmailTemplate(identity.getPrincipal().getName(), request);
+    }
+
     @GET
     @Path("/export/csv")
     @RolesAllowed("ADMIN")

--- a/src/main/java/org/santalina/diving/service/BackupService.java
+++ b/src/main/java/org/santalina/diving/service/BackupService.java
@@ -134,6 +134,7 @@ public class BackupService {
                 user.notifOnCreatorRegistration = u.notifOnCreatorRegistration();
                 user.notifOnSafetyReminder  = u.notifOnSafetyReminder();
                 user.clubCertified          = u.clubCertified();
+                user.dpOrganizerEmailTemplate = u.dpOrganizerEmailTemplate();
                 user.createdAt      = LocalDateTime.now();
                 user.updatedAt      = LocalDateTime.now();
                 // Rôles
@@ -326,7 +327,7 @@ public class BackupService {
                 u.activated, u.consentGiven, u.consentDate, roles,
                 u.notifOnRegistration, u.notifOnApproved, u.notifOnCancelled,
                 u.notifOnMovedToWaitlist, u.notifOnDpRegistration, u.notifOnCreatorRegistration,
-                u.notifOnSafetyReminder, u.clubCertified);
+                u.notifOnSafetyReminder, u.clubCertified, u.dpOrganizerEmailTemplate);
     }
 
     private SlotEntry toSlotEntry(DiveSlot s) {

--- a/src/main/java/org/santalina/diving/service/UserService.java
+++ b/src/main/java/org/santalina/diving/service/UserService.java
@@ -184,11 +184,21 @@ public class UserService {
     @Transactional
     public UserResponse updateNotifPrefs(String email, UpdateNotifPrefsRequest request) {
         User user = User.findByEmail(email);
-        if (user == null) throw new NotFoundException("Utilisateur non trouv\u00e9");
+        if (user == null) throw new NotFoundException("Utilisateur non trouvé");
         user.notifOnRegistration    = request.notifOnRegistration();
         user.notifOnApproved        = request.notifOnApproved();
         user.notifOnCancelled       = request.notifOnCancelled();
         user.notifOnMovedToWaitlist = request.notifOnMovedToWaitlist();        user.notifOnDpRegistration  = request.notifOnDpRegistration();        user.notifOnCreatorRegistration = request.notifOnCreatorRegistration();        user.notifOnSafetyReminder = request.notifOnSafetyReminder();        user.persist();
+        return UserResponse.from(user);
+    }
+
+    /** Met à jour le modèle d'email d'organisation du directeur de plongée. */
+    @Transactional
+    public UserResponse updateDpEmailTemplate(String email, UpdateDpEmailTemplateRequest request) {
+        User user = User.findByEmail(email);
+        if (user == null) throw new NotFoundException("Utilisateur non trouvé");
+        user.dpOrganizerEmailTemplate = request.template();
+        user.persist();
         return UserResponse.from(user);
     }
 

--- a/src/main/resources/db/migration/V35__dp_organizer_email_template.sql
+++ b/src/main/resources/db/migration/V35__dp_organizer_email_template.sql
@@ -1,0 +1,2 @@
+-- Mail d'organisation du directeur de plongée
+ALTER TABLE users ADD COLUMN dp_organizer_email_template TEXT;

--- a/src/main/webui/src/App.css
+++ b/src/main/webui/src/App.css
@@ -2039,3 +2039,82 @@ body {
   color: #374151;
   margin: 0 0 2px;
 }
+
+/* ========== MODAL WIDE + MODAL HEADER/BODY/FOOTER ========== */
+.modal--wide { max-width: 860px; }
+
+.modal-header {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 16px; padding-bottom: 12px;
+  border-bottom: 1px solid var(--gray-200);
+}
+.modal-header h3 { margin: 0; font-size: 18px; font-weight: 700; }
+.modal-body {
+  display: flex; flex-direction: column; gap: 12px;
+}
+.modal-footer {
+  display: flex; justify-content: flex-end; gap: 10px;
+  margin-top: 18px; padding-top: 14px;
+  border-top: 1px solid var(--gray-200);
+}
+
+/* ========== PALANQUEE MAIL BUTTON ========== */
+.palanquee-export-btn--mail {
+  background: #2563eb;
+}
+.palanquee-export-btn--mail:hover:not(:disabled) { background: #1d4ed8; }
+
+/* ========== MAIL MODAL SPECIFICS ========== */
+.mail-modal-missing {
+  background: #fef3c7; border: 1px solid #fcd34d; border-radius: 8px;
+  padding: 12px 14px; display: flex; flex-direction: column; gap: 8px; font-size: 13px;
+}
+.mail-modal-missing-row {
+  display: flex; align-items: center; gap: 10px;
+}
+.mail-modal-missing-row span { min-width: 160px; font-weight: 500; }
+.mail-modal-missing-row input {
+  flex: 1; padding: 5px 8px; border: 1px solid var(--gray-300);
+  border-radius: 6px; font-size: 13px;
+}
+.mail-modal-vars {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 6px;
+  padding: 8px 10px; background: var(--gray-50); border-radius: 6px;
+}
+.mail-modal-var-chip {
+  font-size: 11px; font-family: monospace; padding: 2px 7px;
+  background: #e0e7ff; color: #3730a3; border-radius: 4px;
+  cursor: pointer; user-select: none;
+  transition: background 0.12s;
+}
+.mail-modal-var-chip:hover { background: #c7d2fe; }
+
+/* ========== RICH TEXT EDITOR ========== */
+.rte {
+  border: 1px solid var(--gray-300); border-radius: 8px; overflow: hidden;
+  font-size: 14px;
+}
+.rte-toolbar {
+  display: flex; flex-wrap: wrap; gap: 2px; padding: 6px 8px;
+  background: var(--gray-50); border-bottom: 1px solid var(--gray-200);
+}
+.rte-btn {
+  padding: 3px 8px; background: none; border: 1px solid transparent;
+  border-radius: 4px; font-size: 13px; cursor: pointer; color: var(--gray-700);
+  transition: background 0.12s;
+}
+.rte-btn:hover { background: var(--gray-200); }
+.rte-btn.active { background: var(--primary-light); color: var(--primary); border-color: var(--primary); }
+.rte-sep { width: 1px; background: var(--gray-300); margin: 2px 4px; align-self: stretch; }
+.rte-content {
+  min-height: 320px; padding: 12px 14px; outline: none; overflow-y: auto;
+  line-height: 1.6;
+}
+.rte-content:empty:before {
+  content: attr(data-placeholder); color: var(--gray-400); pointer-events: none;
+}
+.rte-content h2 { font-size: 18px; font-weight: 700; margin: 10px 0 4px; }
+.rte-content h3 { font-size: 15px; font-weight: 700; margin: 8px 0 4px; }
+.rte-content p { margin: 0 0 8px; }
+.rte-content ul, .rte-content ol { padding-left: 20px; margin: 4px 0 8px; }
+.rte-content li { margin-bottom: 3px; }

--- a/src/main/webui/src/components/RichTextEditor.tsx
+++ b/src/main/webui/src/components/RichTextEditor.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useRef, type ReactNode } from 'react';
+
+interface RichTextEditorProps {
+  /** HTML initial (lu une seule fois au montage) */
+  initialValue: string;
+  onChange: (html: string) => void;
+  placeholder?: string;
+  minHeight?: number;
+}
+
+/**
+ * Éditeur WYSIWYG minimal basé sur contentEditable.
+ * Barre d'outils : Gras, Italique, Souligné, H2, H3, Paragraphe, Liste puces, Liste numérotée.
+ * Pas de dépendance externe.
+ */
+export function RichTextEditor({ initialValue, onChange, placeholder, minHeight = 320 }: RichTextEditorProps) {
+  const editorRef = useRef<HTMLDivElement>(null);
+
+  // Initialise le contenu une seule fois
+  useEffect(() => {
+    if (editorRef.current) {
+      editorRef.current.innerHTML = initialValue;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const exec = (cmd: string, arg?: string) => {
+    editorRef.current?.focus();
+    // execCommand est déprécié mais reste fonctionnel dans tous les navigateurs actuels
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    document.execCommand(cmd, false, arg ?? undefined);
+  };
+
+  const tbBtn = (label: ReactNode, title: string, handler: () => void) => (
+    <button
+      key={title}
+      type="button"
+      className="rte-btn"
+      title={title}
+      onMouseDown={(e) => { e.preventDefault(); handler(); }}
+    >
+      {label}
+    </button>
+  );
+
+  return (
+    <div className="rte">
+      {/* Barre d'outils */}
+      <div className="rte-toolbar">
+        {tbBtn(<><b>G</b></>, 'Gras (Ctrl+B)', () => exec('bold'))}
+        {tbBtn(<><i>I</i></>, 'Italique (Ctrl+I)', () => exec('italic'))}
+        {tbBtn(<><u>S</u></>, 'Souligné (Ctrl+U)', () => exec('underline'))}
+        <span className="rte-sep" />
+        {tbBtn('H2', 'Titre 2', () => exec('formatBlock', 'h2'))}
+        {tbBtn('H3', 'Titre 3', () => exec('formatBlock', 'h3'))}
+        {tbBtn('¶', 'Paragraphe', () => exec('formatBlock', 'p'))}
+        <span className="rte-sep" />
+        {tbBtn('• Liste', 'Liste à puces', () => exec('insertUnorderedList'))}
+        {tbBtn('1. Liste', 'Liste numérotée', () => exec('insertOrderedList'))}
+        <span className="rte-sep" />
+        {tbBtn('↺', 'Annuler (Ctrl+Z)', () => exec('undo'))}
+        {tbBtn('↻', 'Rétablir (Ctrl+Y)', () => exec('redo'))}
+      </div>
+
+      {/* Zone éditable */}
+      <div
+        ref={editorRef}
+        contentEditable
+        suppressContentEditableWarning
+        className="rte-content"
+        data-placeholder={placeholder ?? 'Rédigez votre message ici...'}
+        style={{ minHeight }}
+        onInput={() => {
+          if (editorRef.current) onChange(editorRef.current.innerHTML);
+        }}
+      />
+    </div>
+  );
+}

--- a/src/main/webui/src/pages/HelpPage.tsx
+++ b/src/main/webui/src/pages/HelpPage.tsx
@@ -398,7 +398,7 @@ export function HelpPage() {
             </li>
           </ol>
           <div className="help-tip">
-            💡 Les plongeurs validés apparaissent dans le pool <strong>Non assignés</strong> de la page d'organisation des palanquées.
+            💡 Les plongeurs validés apparaissent dans la réserve <strong>Non assignés</strong> de la page d'organisation des palanquées.
           </div>
 
           <h4>Remettre un plongeur en liste d'attente</h4>
@@ -832,10 +832,44 @@ export function HelpPage() {
           { type: 'h4' as const, text: 'Accéder à la page' },
           { type: 'ol' as const, items: ['Cliquez sur un créneau pour ouvrir le panneau de détails.', 'Cliquez sur Organiser les palanquées.'] },
           { type: 'h4' as const, text: 'Répartir les plongeurs' },
-          { type: 'ul' as const, items: ['Glissez-déposez une fiche vers une palanquée ou vers "+ Nouvelle palanquée".', 'Pour retirer un plongeur d\'une palanquée, glissez-le vers la zone Non assignés.'] },
+          { type: 'ul' as const, items: ['Glissez-déposez une fiche vers une palanquée ou vers "+ Nouvelle palanquée".', 'Pour retirer un plongeur d\'une palanquée, glissez-le vers la zone Non assignés.', 'Sur mobile, sélectionnez un plongeur puis choisissez une palanquée ou « Réserve » pour le remettre dans la zone non assignée.'] },
           { type: 'h4' as const, text: 'Modifier le niveau ou les aptitudes' },
           { type: 'ul' as const, items: ['Double-cliquez sur le niveau affiché pour le modifier.', 'Double-cliquez sur la zone aptitudes pour sélectionner : PE12–PE60, PA12–PA60, E1–E4, GP.', 'Les aptitudes apparaissent en colonne D de l\'export Excel.'] },
           { type: 'tip' as const, text: 'Les modifications de niveau et d\'aptitudes sont enregistrées immédiatement sur le serveur.' },
+        ],
+      },
+      {
+        icon: '📧', title: 'Mail d\'organisation',
+        items: [
+          { type: 'paragraph' as const, text: 'Depuis la page Organisation des palanquées, vous pouvez envoyer un email groupé à tous les plongeurs inscrits sur le créneau.' },
+          { type: 'h4' as const, text: 'Envoyer le mail' },
+          { type: 'ol' as const, items: [
+            'Ouvrez la page Palanquées d\'un créneau.',
+            'Cliquez sur 📧 Mail d\'organisation.',
+            'Vérifiez ou modifiez l\'objet et le corps du mail.',
+            'Si des plongeurs n\'ont pas d\'email enregistré, un champ de saisie manuel s\'affiche pour chacun d\'eux — il reste visible jusqu\'au clic sur Envoyer.',
+            'Cliquez sur 📧 Envoyer.',
+          ] },
+          { type: 'h4' as const, text: 'Destinataires' },
+          { type: 'ul' as const, items: [
+            'Les plongeurs inscrits sont en CCI (BCC) — ils ne voient pas les adresses des autres.',
+            'Vous (le directeur de plongée) êtes en CC.',
+            'Le champ Reply-To pointe vers votre email : les réponses vous sont adressées directement.',
+          ] },
+          { type: 'h4' as const, text: 'Variables' },
+          { type: 'paragraph' as const, text: 'Le corps du mail peut contenir des variables qui sont remplacées automatiquement :' },
+          { type: 'ul' as const, items: [
+            '{siteName} — nom du site de plongée',
+            '{slotDate} — date du créneau',
+            '{startTime} / {endTime} — horaires',
+            '{slotTitle} — titre du créneau (si renseigné)',
+            '{dpName} — votre nom',
+            '{dpEmail} — votre email',
+            '{dpPhone} — votre téléphone',
+          ] },
+          { type: 'h4' as const, text: 'Personnaliser le modèle par défaut' },
+          { type: 'paragraph' as const, text: 'Vous pouvez enregistrer votre propre modèle de mail dans Mon profil → 📧 Modèle d\'e-mail d\'organisation. Ce modèle sera pré-chargé à chaque ouverture de l\'éditeur.' },
+          { type: 'tip' as const, text: 'L\'éditeur WYSIWYG supporte le gras, l\'italique, le souligné, les titres H2/H3, les listes à puces et numérotées.' },
         ],
       },
     ] : []),

--- a/src/main/webui/src/pages/PalanqueePage.tsx
+++ b/src/main/webui/src/pages/PalanqueePage.tsx
@@ -4,7 +4,11 @@ import { palanqueeService } from '../services/palanqueeService';
 import { slotService } from '../services/slotService';
 import { waitingListService } from '../services/waitingListService';
 import { adminService } from '../services/adminService';
+import { authService } from '../services/authService';
+import { slotMailService } from '../services/slotMailService';
 import { exportDiverListCsv } from '../utils/exportDiverList';
+import { RichTextEditor } from '../components/RichTextEditor';
+import { DpOrganizerMailer } from '../utils/dpMailDefaults';
 import type { DiveSlot, SlotDiver, Palanquee, WaitingListEntry } from '../types';
 
 // ── constantes ──────────────────────────────────────────────────────────────
@@ -278,6 +282,16 @@ export function PalanqueePage({ slotId, onBack }: Props) {
   const renameInputRef = useRef<HTMLInputElement>(null);
 
   const [saving, setSaving] = useState(false);
+
+  // ── Mail d'organisation DP ─────────────────────────────────────────────
+  const [showMailModal, setShowMailModal] = useState(false);
+  const [mailSubject, setMailSubject]     = useState('');
+  const [mailBody, setMailBody]           = useState('');
+  const [mailBodyKey, setMailBodyKey]     = useState(0); // force re-mount RichTextEditor
+  const [emailOverrides, setEmailOverrides] = useState<Record<number, string>>({});
+  const [mailSending, setMailSending]     = useState(false);
+  const [mailSuccess, setMailSuccess]     = useState('');
+  const [mailError, setMailError]         = useState('');
   const [exporting, setExporting] = useState(false);
 
   // ── mobile ─────────────────────────────────────────────────────────────────
@@ -683,6 +697,55 @@ export function PalanqueePage({ slotId, onBack }: Props) {
     }
   };
 
+  // ── mail d'organisation ───────────────────────────────────────────────────
+  const handleOpenMailModal = async () => {
+    setMailSuccess(''); setMailError('');
+    // Charger le profil pour récupérer le modèle enregistré
+    let template = DpOrganizerMailer.DEFAULT_TEMPLATE;
+    try {
+      const profile = await authService.getProfile();
+      if (profile.dpOrganizerEmailTemplate) template = profile.dpOrganizerEmailTemplate;
+    } catch { /* utiliser le modèle par défaut */ }
+
+    const defSubject = slot
+      ? `Organisation sortie ${slot.slotDate} \u2014 ${slot.title ?? slot.slotType ?? 'plongée'}`
+      : 'Organisation de la sortie';
+
+    setMailSubject(defSubject);
+    setMailBody(template);
+    setEmailOverrides({});
+    setMailBodyKey(k => k + 1); // force RichTextEditor remount avec le nouveau contenu
+    setShowMailModal(true);
+  };
+
+  const isValidEmail = (v: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v.trim());
+
+  const handleSendOrganizationMail = async () => {
+    setMailSending(true); setMailError(''); setMailSuccess('');
+    try {
+      const result = await slotMailService.sendOrganizationMail(
+        slotId, mailSubject, mailBody,
+        Object.keys(emailOverrides).length ? emailOverrides : undefined,
+      );
+      if (result.missingEmails.length > 0) {
+        // Le serveur a retourné des emails manquants (ne devrait pas arriver si le front valide)
+        const names = result.missingEmails.map(m => m.diverName).join(', ');
+        setMailError(`Emails manquants pour : ${names}. Veuillez les saisir ci-dessous.`);
+        const newOv: Record<number, string> = { ...emailOverrides };
+        result.missingEmails.forEach(m => { if (!newOv[m.diverId]) newOv[m.diverId] = ''; });
+        setEmailOverrides(newOv);
+      } else {
+        setMailSuccess(`Mail envoyé avec succès à ${result.sent} destinataire(s).`);
+        setTimeout(() => setShowMailModal(false), 2000);
+      }
+    } catch (err: unknown) {
+      const m = (err as { response?: { data?: { message?: string } } })?.response?.data?.message;
+      setMailError(m ?? 'Erreur lors de l\'envoi du mail.');
+    } finally {
+      setMailSending(false);
+    }
+  };
+
   // ── rendu ─────────────────────────────────────────────────────────────────
   if (loading) {
     return (
@@ -734,6 +797,14 @@ export function PalanqueePage({ slotId, onBack }: Props) {
             title="Exporter la fiche de sécurité Excel avec les palanquées"
           >
             {exporting ? '…' : '📥 Export Excel'}
+          </button>
+          <button
+            className="palanquee-export-btn palanquee-export-btn--mail"
+            onClick={handleOpenMailModal}
+            disabled={allDivers.length === 0}
+            title="Envoyer un mail d'organisation aux plongeurs inscrits"
+          >
+            📧 Mail d'organisation
           </button>
         </div>
       </div>
@@ -1110,7 +1181,7 @@ export function PalanqueePage({ slotId, onBack }: Props) {
                   className="palanquee-mobile-action-btn palanquee-mobile-action-btn--pool"
                   onClick={() => handleMobileAssign(null)}
                 >
-                  📋 Pool
+                  📋 Réserve
                 </button>
               )}
               {palanquees.map((p, idx) => (
@@ -1132,6 +1203,113 @@ export function PalanqueePage({ slotId, onBack }: Props) {
           </div>
         );
       })()}
+
+      {/* ── Modal mail d'organisation DP ─────────────────────────────────── */}
+      {showMailModal && (
+        <div className="modal-overlay" onClick={() => !mailSending && setShowMailModal(false)}>
+          <div className="modal modal--wide" onClick={e => e.stopPropagation()}>
+            <div className="modal-header">
+              <h3>📧 Mail d'organisation</h3>
+              <button className="modal-close" onClick={() => setShowMailModal(false)} disabled={mailSending}>✕</button>
+            </div>
+
+            <div className="modal-body" style={{ gap: 14 }}>
+              {/* Emails manquants */}
+              {(() => {
+                const missingDivers = allDivers.filter(d => !d.email);
+                if (missingDivers.length === 0) return null;
+                return (
+                  <div className="mail-modal-missing">
+                    <strong>⚠️ Emails manquants — saisir manuellement :</strong>
+                    {missingDivers.map(d => {
+                        const val = emailOverrides[d.id] ?? '';
+                        const invalid = val.trim() !== '' && !isValidEmail(val);
+                        return (
+                          <div key={d.id} className="mail-modal-missing-row">
+                            <span>{d.firstName} {d.lastName}</span>
+                            <input
+                              type="email"
+                              placeholder="email@example.com"
+                              value={val}
+                              onChange={e => setEmailOverrides(prev => ({ ...prev, [d.id]: e.target.value }))}
+                              style={invalid ? { borderColor: '#ef4444' } : undefined}
+                            />
+                            {invalid && <span style={{ fontSize: 11, color: '#ef4444' }}>Format invalide</span>}
+                          </div>
+                        );
+                      })}
+                  </div>
+                );
+              })()}
+
+              {/* Objet */}
+              <div className="form-group">
+                <label style={{ fontSize: 13 }}>Objet du mail</label>
+                <input
+                  type="text"
+                  value={mailSubject}
+                  onChange={e => setMailSubject(e.target.value)}
+                  style={{ width: '100%' }}
+                />
+              </div>
+
+              {/* Variables disponibles */}
+              <div className="mail-modal-vars">
+                <span style={{ fontSize: 12, color: '#6b7280', marginRight: 6 }}>Variables :</span>
+                {['{siteName}', '{slotDate}', '{startTime}', '{endTime}', '{slotTitle}',
+                  '{dpName}', '{dpEmail}', '{dpPhone}'].map(v => (
+                  <span key={v} className="mail-modal-var-chip" title="Cliquez pour copier"
+                    onClick={() => navigator.clipboard.writeText(v).catch(() => {})}
+                  >{v}</span>
+                ))}
+              </div>
+
+              {/* Éditeur WYSIWYG */}
+              <div className="form-group">
+                <label style={{ fontSize: 13 }}>Corps du mail</label>
+                <RichTextEditor
+                  key={mailBodyKey}
+                  initialValue={mailBody}
+                  onChange={setMailBody}
+                  minHeight={380}
+                />
+              </div>
+
+              {/* Récapitulatif destinataires */}
+              <div style={{ fontSize: 12, color: '#6b7280' }}>
+                {(() => {
+                  const count = allDivers.filter(
+                    d => (d.email && d.email.trim()) || (emailOverrides[d.id] ?? '').trim(),
+                  ).length;
+                  return `${count} / ${allDivers.length} plongeur(s) ont une adresse mail · Vous serez en CC`;
+                })()}
+              </div>
+
+              {mailError   && <div className="alert alert-error">{mailError}</div>}
+              {mailSuccess && <div className="alert alert-success">{mailSuccess}</div>}
+            </div>
+
+            <div className="modal-footer">
+              <button className="btn btn-outline" onClick={() => setShowMailModal(false)} disabled={mailSending}>
+                Annuler
+              </button>
+              <button
+                className="btn btn-primary"
+                onClick={handleSendOrganizationMail}
+                disabled={
+                  mailSending ||
+                  !mailSubject.trim() ||
+                  !mailBody.trim() ||
+                  allDivers.some(d => !d.email && !(emailOverrides[d.id] ?? '').trim()) ||
+                  Object.values(emailOverrides).some(v => v.trim() !== '' && !isValidEmail(v))
+                }
+              >
+                {mailSending ? '⏳ Envoi…' : '📧 Envoyer'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/main/webui/src/pages/ProfilePage.tsx
+++ b/src/main/webui/src/pages/ProfilePage.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState } from 'react';
 import { useAuth } from '../context/AuthContext';
 import { authService } from '../services/authService';
 import { adminService } from '../services/adminService';
+import { RichTextEditor } from '../components/RichTextEditor';
+import { DpOrganizerMailer } from '../utils/dpMailDefaults';
 
 export function ProfilePage() {
   const { user } = useAuth();
@@ -25,6 +27,9 @@ export function ProfilePage() {
   const [notifOnCreatorRegistration, setNotifOnCreatorRegistration] = useState(user?.notifOnCreatorRegistration ?? false);
   const [notifOnSafetyReminder, setNotifOnSafetyReminder] = useState(user?.notifOnSafetyReminder ?? true);
   const [notifLoading, setNotifLoading] = useState(false);
+  const [dpTemplate, setDpTemplate]     = useState(DpOrganizerMailer.DEFAULT_TEMPLATE);
+  const [dpTemplateKey, setDpTemplateKey] = useState(0);
+  const [dpTemplateLoading, setDpTemplateLoading] = useState(false);
 
   // Scroll vers la section notifications si le hash #notifications est présent dans l'URL
   useEffect(() => {
@@ -48,6 +53,9 @@ export function ProfilePage() {
       setNotifOnDpRegistration(profile.notifOnDpRegistration ?? true);
       setNotifOnCreatorRegistration(profile.notifOnCreatorRegistration ?? false);
       setNotifOnSafetyReminder(profile.notifOnSafetyReminder ?? true);
+      const tpl = profile.dpOrganizerEmailTemplate || DpOrganizerMailer.DEFAULT_TEMPLATE;
+      setDpTemplate(tpl);
+      setDpTemplateKey(k => k + 1);
     }).catch(() => {
       // Repli sur les données du contexte si l'API échoue
       setFirstName(user?.firstName || '');
@@ -96,6 +104,18 @@ export function ProfilePage() {
       setError(m || 'Erreur lors du changement de mot de passe');
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleSaveDpTemplate = async () => {
+    setMsg(''); setError(''); setDpTemplateLoading(true);
+    try {
+      await authService.updateDpEmailTemplate(dpTemplate);
+      setMsg('Modèle de mail enregistré.');
+    } catch {
+      setError('Erreur lors de l\'enregistrement du modèle.');
+    } finally {
+      setDpTemplateLoading(false);
     }
   };
 
@@ -225,6 +245,32 @@ export function ProfilePage() {
             {notifLoading ? '...' : '💾 Enregistrer'}
           </button>
         </div>
+
+        {(user.role === 'DIVE_DIRECTOR' || user.role === 'ADMIN') && (
+          <div className="profile-section">
+            <h3>📧 Modèle d'e-mail d'organisation</h3>
+            <p style={{ color: '#6b7280', fontSize: 13, marginBottom: 8 }}>
+              Ce modèle est pré-chargé dans l'éditeur lorsque vous envoyez un mail
+              d'organisation depuis la page Palanquées.{' '}
+              <br />Variables disponibles :
+              {['{siteName}', '{slotDate}', '{startTime}', '{endTime}', '{slotTitle}',
+                '{dpName}', '{dpEmail}', '{dpPhone}'].map(v => (
+                <code key={v} style={{ margin: '0 3px', background: '#e0e7ff', borderRadius: 3, padding: '1px 4px', fontSize: 11 }}>{v}</code>
+              ))}
+            </p>
+            <RichTextEditor
+              key={dpTemplateKey}
+              initialValue={dpTemplate}
+              onChange={setDpTemplate}
+              minHeight={400}
+            />
+            <div style={{ marginTop: 10 }}>
+              <button className="btn btn-primary" onClick={handleSaveDpTemplate} disabled={dpTemplateLoading}>
+                {dpTemplateLoading ? '...' : '💾 Enregistrer le modèle'}
+              </button>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/main/webui/src/services/authService.ts
+++ b/src/main/webui/src/services/authService.ts
@@ -57,6 +57,11 @@ export const authService = {
     return res.data;
   },
 
+  async updateDpEmailTemplate(template: string): Promise<User> {
+    const res = await api.put<User>('/users/me/dp-email-template', { template });
+    return res.data;
+  },
+
   async updateEmail(email: string): Promise<LoginResponse> {
     const res = await api.patch<LoginResponse>('/users/me/email', { email });
     // Mettre à jour le token et l'utilisateur stockés

--- a/src/main/webui/src/services/slotMailService.ts
+++ b/src/main/webui/src/services/slotMailService.ts
@@ -1,0 +1,26 @@
+import api from './api';
+
+export interface MissingEmailInfo {
+  diverId: number;
+  diverName: string;
+}
+
+export interface OrganizationMailResponse {
+  sent: number;
+  missingEmails: MissingEmailInfo[];
+}
+
+export const slotMailService = {
+  async sendOrganizationMail(
+    slotId: number,
+    subject: string,
+    htmlBody: string,
+    emailOverrides?: Record<number, string>,
+  ): Promise<OrganizationMailResponse> {
+    const res = await api.post<OrganizationMailResponse>(
+      `/slots/${slotId}/mail/organization`,
+      { subject, htmlBody, emailOverrides: emailOverrides ?? {} },
+    );
+    return res.data;
+  },
+};

--- a/src/main/webui/src/types/index.ts
+++ b/src/main/webui/src/types/index.ts
@@ -20,6 +20,7 @@ export interface User {
   notifOnDpRegistration?: boolean;
   notifOnCreatorRegistration?: boolean;
   notifOnSafetyReminder?: boolean;
+  dpOrganizerEmailTemplate?: string;
 }
 
 export interface LoginResponse {

--- a/src/main/webui/src/utils/dpMailDefaults.ts
+++ b/src/main/webui/src/utils/dpMailDefaults.ts
@@ -1,0 +1,64 @@
+/**
+ * Données par défaut pour l'email d'organisation du directeur de plongée.
+ * Ce module est le miroir frontend du DEFAULT_TEMPLATE Java (DpOrganizerMailer.java).
+ *
+ * Variables disponibles : {siteName}, {slotDate}, {startTime}, {endTime},
+ *                         {slotTitle}, {dpName}, {dpEmail}, {dpPhone}
+ */
+
+const DEFAULT_TEMPLATE =
+  '<p>Bonjour à tous,</p>' +
+  '<p>Vous êtes inscrits à la sortie du <strong>{slotDate}</strong> à la {siteName} ' +
+  '(RDV à la {siteName} à {startTime}).</p>' +
+  '<p>Voici quelques informations utiles à l\'organisation de cette plongée.</p>' +
+  '<h3>Horaires</h3>' +
+  '<ul>' +
+  '<li>Récupérez le matériel dans votre club, 1 bloc pour chaque plongée.</li>' +
+  '<li>Pour ceux qui ont déjà tout le matériel, rendez-vous directement à la {siteName} à {startTime}. ' +
+  'Dans ce cas merci de me prévenir.</li>' +
+  '<li>Prévoyez de quoi pique-niquer sur place après la plongée et de vous hydrater ' +
+  '(1 bouteille d\'eau ou gourde par personne).</li>' +
+  '</ul>' +
+  '<h3>Administratif</h3>' +
+  '<ul>' +
+  '<li>Pensez à prendre les papiers nécessaires à la plongée :<br/>' +
+  'Certificat médical, Carte de niveau, Carnet de plongée, Licence</li>' +
+  '</ul>' +
+  '<p><strong>==&gt; Pas de papiers = Pas de plongée</strong></p>' +
+  '<ul>' +
+  '<li>Prenez également vos fiches de progression et de suivi.</li>' +
+  '<li>Pensez à contrôler vos papiers avant samedi matin\u00a0! Licence active et CACI valide\u00a0!</li>' +
+  '</ul>' +
+  '<h3>Météo</h3>' +
+  '<p>Pensez à prendre des vêtements chauds pour couvrir entre les 2 plongées.</p>' +
+  '<p>La température de l\'eau peut être inférieure à 10\u00a0°C au-delà de 3\u00a0m. ' +
+  'Prévoyez une combinaison adaptée, des gants, des chaussons et une cagoule. ' +
+  'Pensez également à prendre vos plombs\u00a0!</p>' +
+  '<h3>Règles de vie à la {siteName}</h3>' +
+  '<ul>' +
+  '<li>Les véhicules doivent être stationnés sur les emplacements prévus à cet effet. ' +
+  'Attention\u00a0! ne pas se garer sur la pelouse des locataires.</li>' +
+  '<li>Au niveau du plan d\'eau, aucun véhicule ne doit stationner. ' +
+  'On peut décharger/charger son matériel, puis se garer sur le parking au niveau du local.</li>' +
+  '<li>Pour le pique-nique, nous le prendrons dans le local pour ne pas avoir froid.</li>' +
+  '</ul>' +
+  '<h3>Rappel sur le règlement spécifique de la {siteName}</h3>' +
+  '<ul>' +
+  '<li>Espace médian 6-20\u00a0m\u00a0: chaque plongeur au-delà de 20\u00a0m doit être équipé de 2 premiers étages ' +
+  'et d\'une lampe flash.</li>' +
+  '<li>Espace lointain +20\u00a0m\u00a0: le guide de palanquée doit avoir une source de lumière ' +
+  '(autre que la lampe flash).</li>' +
+  '</ul>' +
+  '<p>La présence d\'un parachute de palier par palanquée (pour les encadrants) est obligatoire ' +
+  '(Code du sport).</p>' +
+  '<p>En cas de contre-temps ou de retard, merci de me prévenir au plus tôt par mail ou téléphone ' +
+  'afin que je puisse ajuster mon organisation.</p>' +
+  '<p>({dpPhone} ou {dpEmail}).</p>' +
+  '<p>Je reste à votre disposition pour toutes questions complémentaires.</p>' +
+  '<p>Bonne fin de semaine à tous et à bientôt,</p>' +
+  '<p><strong>{dpName}</strong><br/>{dpPhone}</p>';
+
+/** Miroir frontend de DpOrganizerMailer.DEFAULT_TEMPLATE (Java) */
+export const DpOrganizerMailer = {
+  DEFAULT_TEMPLATE,
+};

--- a/src/test/java/org/santalina/diving/integration/SlotMailResourceIT.java
+++ b/src/test/java/org/santalina/diving/integration/SlotMailResourceIT.java
@@ -1,0 +1,119 @@
+package org.santalina.diving.integration;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Tests d'intégration des endpoints /api/slots/{slotId}/mail.
+ */
+@QuarkusTest
+class SlotMailResourceIT {
+
+    private static final String MAIL_PATH = "/api/slots/{slotId}/mail/organization";
+    private static final long   UNKNOWN_SLOT = 999999L;
+
+    /* ── Accès protégé (non authentifié) ── */
+
+    @Test
+    void sendOrganizationMail_shouldReturn401_withoutAuthentication() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"subject\":\"Test\",\"htmlBody\":\"<p>Hello</p>\"}")
+                .pathParam("slotId", 1)
+                .when().post(MAIL_PATH)
+                .then()
+                .statusCode(401);
+    }
+
+    /* ── Contrôle des rôles ── */
+
+    @Test
+    @TestSecurity(user = "diver@test.com", roles = {"DIVER"})
+    void sendOrganizationMail_shouldReturn403_whenDiver() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"subject\":\"Test\",\"htmlBody\":\"<p>Hello</p>\"}")
+                .pathParam("slotId", 1)
+                .when().post(MAIL_PATH)
+                .then()
+                .statusCode(403);
+    }
+
+    /* ── Validation des entrées ── */
+
+    @Test
+    @TestSecurity(user = "admin@santalina.com", roles = {"ADMIN"})
+    void sendOrganizationMail_shouldReturn404_whenSlotNotFound() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"subject\":\"Sortie\",\"htmlBody\":\"<p>Bonjour</p>\"}")
+                .pathParam("slotId", UNKNOWN_SLOT)
+                .when().post(MAIL_PATH)
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    @TestSecurity(user = "admin@santalina.com", roles = {"ADMIN"})
+    void sendOrganizationMail_shouldReturn400_whenSubjectMissing() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"subject\":\"\",\"htmlBody\":\"<p>Bonjour</p>\"}")
+                .pathParam("slotId", 1)
+                .when().post(MAIL_PATH)
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    @TestSecurity(user = "admin@santalina.com", roles = {"ADMIN"})
+    void sendOrganizationMail_shouldReturn400_whenBodyMissing() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"subject\":\"Sortie\",\"htmlBody\":\"\"}")
+                .pathParam("slotId", 1)
+                .when().post(MAIL_PATH)
+                .then()
+                .statusCode(400);
+    }
+
+    /* ── Endpoint de template DP ── */
+
+    @Test
+    void updateDpEmailTemplate_shouldReturn401_withoutAuthentication() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"template\":\"<p>Bonjour</p>\"}")
+                .when().put("/api/users/me/dp-email-template")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    @TestSecurity(user = "diver@test.com", roles = {"DIVER"})
+    void updateDpEmailTemplate_shouldReturn403_whenDiver() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"template\":\"<p>Bonjour</p>\"}")
+                .when().put("/api/users/me/dp-email-template")
+                .then()
+                .statusCode(403);
+    }
+
+    @Test
+    @TestSecurity(user = "admin@santalina.com", roles = {"ADMIN"})
+    void updateDpEmailTemplate_shouldReturn200_whenAdmin() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"template\":\"<p>Mon modèle</p>\"}")
+                .when().put("/api/users/me/dp-email-template")
+                .then()
+                .statusCode(200)
+                .body("dpOrganizerEmailTemplate", equalTo("<p>Mon modèle</p>"));
+    }
+}


### PR DESCRIPTION
- Nouveau endpoint POST /api/slots/{id}/mail/organization (ADMIN, DIVE_DIRECTOR) · Retourne 422 si des plongeurs n'ont pas d'email (avec la liste) · Valide le format des emails saisis manuellement · Envoie un mail individuel par plongeur + copie [Copie] au DP · La copie DP liste les adresses destinataires en bas de mail · Reply-To = email du DP

- Nouveau endpoint PUT /api/users/me/dp-email-template (ADMIN, DIVE_DIRECTOR) · Permet au DP d'enregistrer son modèle d'email personnalisé

- Modèle par défaut variabilisé : {siteName}, {slotDate}, {startTime}, {endTime}, {slotTitle}, {dpName}, {dpEmail}, {dpPhone}

- Migration Flyway V35 : colonne dp_organizer_email_template sur users
- Backup/restore étendu au nouveau champ

- Frontend : · Bouton "📧 Mail d'organisation" sur la page Palanquées · Modal avec éditeur WYSIWYG (contentEditable, sans dépendance) · Chips variables cliquables (copier dans le presse-papiers) · Saisie manuelle des emails manquants avec validation de format · Section "Modèle d'email" dans Mon profil (DP/ADMIN uniquement)

- Renommage "Pool" → "Réserve" dans l'action mobile palanquées
- Aide en ligne mise à jour (section dédiée + corrections)
- Tests d'intégration SlotMailResourceIT
- README mis à jour