### PR TITLE
feat: modèle d'e-mail d'organisation configurable en admin + fix obje…

### DIFF
--- a/src/main/java/org/santalina/diving/dto/ConfigDto.java
+++ b/src/main/java/org/santalina/diving/dto/ConfigDto.java
@@ -41,7 +41,8 @@ public class ConfigDto {
             boolean reportEmailEnabled,
             int reportEmailPeriodDays,
             String reportEmailRecipients,
-            String reportEmailLastSent
+            String reportEmailLastSent,
+            String defaultOrganizerMailTemplate
     ) {}
 
     public record UpdateMaxRecurringMonthsRequest(
@@ -103,5 +104,9 @@ public class ConfigDto {
             @NotBlank String toDate,
             String recipients,
             String club
+    ) {}
+
+    public record UpdateOrganizerMailTemplateRequest(
+            String template
     ) {}
 }

--- a/src/main/java/org/santalina/diving/resource/ConfigResource.java
+++ b/src/main/java/org/santalina/diving/resource/ConfigResource.java
@@ -189,6 +189,14 @@ public class ConfigResource {
         );
     }
 
+    @PUT
+    @Path("/organizer-mail-template")
+    @RolesAllowed("ADMIN")
+    public ConfigResponse updateOrganizerMailTemplate(UpdateOrganizerMailTemplateRequest request) {
+        return configService.updateDefaultOrganizerMailTemplate(
+                request != null ? request.template() : null);
+    }
+
     @POST
     @Path("/report-email-send")
     @RolesAllowed("ADMIN")

--- a/src/main/java/org/santalina/diving/service/ConfigService.java
+++ b/src/main/java/org/santalina/diving/service/ConfigService.java
@@ -56,6 +56,8 @@ public class ConfigService {
     private static final String KEY_REPORT_EMAIL_RECIPIENTS  = "report.email.recipients";
     private static final String KEY_REPORT_EMAIL_LAST_SENT   = "report.email.last.sent";
 
+    private static final String KEY_DEFAULT_ORGANIZER_MAIL_TEMPLATE = "dp.organizer.mail.template.default";
+
     private static final String DEFAULT_SAFETY_REMINDER_BODY =
         "Ce rappel vous est envoyé car vous êtes le directeur de plongée du créneau du {slotDate} sur le site {siteName}.\n\n" +
         "Pensez à transmettre la fiche de sécurité remplie à votre club si ce n'est pas encore fait.";
@@ -199,6 +201,10 @@ public class ConfigService {
         return getStringValue(KEY_REPORT_EMAIL_LAST_SENT, "");
     }
 
+    public String getDefaultOrganizerMailTemplate() {
+        return getStringValue(KEY_DEFAULT_ORGANIZER_MAIL_TEMPLATE, "");
+    }
+
     public ConfigResponse getConfig() {
         return new ConfigResponse(
                 getMaxDivers(), getSlotMinHours(), getSlotMaxHours(),
@@ -223,7 +229,8 @@ public class ConfigService {
                 isReportEmailEnabled(),
                 getReportEmailPeriodDays(),
                 getReportEmailRecipients(),
-                getReportEmailLastSent()
+                getReportEmailLastSent(),
+                getDefaultOrganizerMailTemplate()
         );
     }
 
@@ -295,6 +302,12 @@ public class ConfigService {
         forceUpsert(KEY_REPORT_EMAIL_ENABLED,     String.valueOf(enabled));
         forceUpsert(KEY_REPORT_EMAIL_PERIOD_DAYS, String.valueOf(periodDays));
         forceUpsert(KEY_REPORT_EMAIL_RECIPIENTS,  recipients != null ? recipients.trim() : "");
+        return getConfig();
+    }
+
+    @Transactional
+    public ConfigResponse updateDefaultOrganizerMailTemplate(String template) {
+        forceUpsert(KEY_DEFAULT_ORGANIZER_MAIL_TEMPLATE, template != null ? template : "");
         return getConfig();
     }
 
@@ -406,6 +419,7 @@ public class ConfigService {
         upsertIfMissing(KEY_REPORT_EMAIL_PERIOD_DAYS,   "7");
         upsertIfMissing(KEY_REPORT_EMAIL_RECIPIENTS,    "");
         upsertIfMissing(KEY_REPORT_EMAIL_LAST_SENT,     "");
+        upsertIfMissing(KEY_DEFAULT_ORGANIZER_MAIL_TEMPLATE, "");
     }
 
     // ---- Helpers privés ----

--- a/src/main/webui/src/pages/AdminPage.tsx
+++ b/src/main/webui/src/pages/AdminPage.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useRef } from 'react';
 import { adminService } from '../services/adminService';
 import type { User, AppConfig, CreateUserRequest, UpdateUserAdminRequest, UserRole, LogInfo, ImportResult, CsvImportResult } from '../types';
 import { getErrorMessage } from '../utils/errorUtils';
+import { RichTextEditor } from '../components/RichTextEditor';
+import { DpOrganizerMailer } from '../utils/dpMailDefaults';
 
 
 const ALL_ROLES: { value: UserRole; label: string }[] = [
@@ -101,6 +103,11 @@ export function AdminPage() {
   const [newMaxRecurringMonths, setNewMaxRecurringMonths] = useState('4');
   const [recurringLoading, setRecurringLoading] = useState(false);
 
+  // Modèle d'e-mail d'organisation par défaut (admin)
+  const [adminOrgMailTemplate, setAdminOrgMailTemplate] = useState('');
+  const [adminOrgMailTemplateKey, setAdminOrgMailTemplateKey] = useState(0);
+  const [adminOrgMailTemplateLoading, setAdminOrgMailTemplateLoading] = useState(false);
+
   // Logs
   const [logs, setLogs]                 = useState<LogInfo[]>([]);
   const [logsLoading, setLogsLoading]   = useState(false);
@@ -143,6 +150,8 @@ export function AdminPage() {
       setBookingOpenHour(c.bookingOpenHour ?? -1);
       setBookingCloseHour(c.bookingCloseHour ?? -1);
       setNotificationEmail(c.notificationBookingEmail ?? '');
+      setAdminOrgMailTemplate(c.defaultOrganizerMailTemplate ?? '');
+      setAdminOrgMailTemplateKey(k => k + 1);
       setNotifRegistration(c.notifRegistrationEnabled ?? true);
       setNotifApproved(c.notifApprovedEnabled ?? true);
       setNotifCancelled(c.notifCancelledEnabled ?? true);
@@ -365,6 +374,20 @@ export function AdminPage() {
       setMsg('Aptitudes mis à jour');
     } catch (err: unknown) { setError(getErrorMessage(err)); }
     finally { setListLoading(false); }
+  };
+
+  const handleSaveAdminOrgMailTemplate = async () => {
+    setAdminOrgMailTemplateLoading(true); setMsg(''); setError('');
+    try {
+      const updated = await adminService.updateOrganizerMailTemplate(adminOrgMailTemplate);
+      setConfig(updated);
+      setAdminOrgMailTemplate(updated.defaultOrganizerMailTemplate ?? '');
+      setMsg("Modèle d'e-mail d'organisation mis à jour");
+    } catch (err: unknown) {
+      setError(getErrorMessage(err));
+    } finally {
+      setAdminOrgMailTemplateLoading(false);
+    }
   };
 
   const handleUpdateBookingHours = async (e: React.FormEvent) => {
@@ -1330,6 +1353,32 @@ export function AdminPage() {
             </div>
           </>
         )}
+      </div>
+
+      {/* Modèle d'e-mail d'organisation par défaut */}
+      <div className="admin-section">
+        <h2>📧 Modèle d'e-mail d'organisation par défaut</h2>
+        <p style={{ color: '#6b7280', fontSize: 13, marginBottom: 8 }}>
+          Ce modèle est utilisé pour les directeurs de plongée qui n'ont pas défini leur propre modèle dans leur profil.
+          Laissez vide pour utiliser le modèle intégré à l'application.
+        </p>
+        <RichTextEditor
+          key={adminOrgMailTemplateKey}
+          initialValue={adminOrgMailTemplate || DpOrganizerMailer.DEFAULT_TEMPLATE}
+          onChange={setAdminOrgMailTemplate}
+        />
+        <div style={{ display: 'flex', gap: 8, marginTop: 12, flexWrap: 'wrap' }}>
+          <button className="btn btn-primary" onClick={handleSaveAdminOrgMailTemplate}
+            disabled={adminOrgMailTemplateLoading}>
+            {adminOrgMailTemplateLoading ? '⏳ ...' : '💾 Enregistrer le modèle'}
+          </button>
+          <button type="button" className="btn btn-secondary" onClick={() => {
+            setAdminOrgMailTemplate('');
+            setAdminOrgMailTemplateKey(k => k + 1);
+          }}>
+            ↩ Remettre le modèle intégré
+          </button>
+        </div>
       </div>
 
       </div>

--- a/src/main/webui/src/pages/HelpPage.tsx
+++ b/src/main/webui/src/pages/HelpPage.tsx
@@ -357,7 +357,11 @@ export function HelpPage() {
             <li><code>{'{dpPhone}'}</code> — votre téléphone</li>
           </ul>
           <h4>Personnaliser le modèle par défaut</h4>
-          <p>Enregistrez votre propre modèle dans <strong>Mon profil → 📧 Modèle d'e-mail d'organisation</strong>. Il sera pré-chargé à chaque ouverture de l'éditeur.</p>
+          <p>Deux niveaux de personnalisation sont disponibles :</p>
+          <ul>
+            <li><strong>Modèle personnel</strong> — enregistrez votre propre modèle dans <strong>Mon profil → 📧 Modèle d'e-mail d'organisation</strong>. Il sera pré-chargé à chaque ouverture de l'éditeur et prend le dessus sur le modèle par défaut.</li>
+            <li><strong>Modèle par défaut du site</strong> — un administrateur peut définir un modèle commun à tous les DP dans <strong>Admin → Référentiels → 📧 Modèle d'e-mail d'organisation par défaut</strong>. Il s'applique pour tout DP qui n'a pas encore défini son propre modèle.</li>
+          </ul>
           <div className="help-tip">💡 L'éditeur WYSIWYG supporte le gras, l'italique, le souligné, les titres H2/H3, les listes à puces et numérotées.</div>
         </>
       ),
@@ -927,7 +931,11 @@ export function HelpPage() {
             '{dpPhone} — votre téléphone',
           ] },
           { type: 'h4' as const, text: 'Personnaliser le modèle par défaut' },
-          { type: 'paragraph' as const, text: 'Vous pouvez enregistrer votre propre modèle de mail dans Mon profil → 📧 Modèle d\'e-mail d\'organisation. Ce modèle sera pré-chargé à chaque ouverture de l\'éditeur.' },
+          { type: 'paragraph' as const, text: 'Deux niveaux de personnalisation sont disponibles :' },
+          { type: 'ul' as const, items: [
+            'Modèle personnel — enregistrez votre propre modèle dans Mon profil → 📧 Modèle d\'e-mail d\'organisation.',
+            'Modèle par défaut du site — un administrateur peut définir un modèle commun dans Admin → Référentiels → 📧 Modèle d\'e-mail d\'organisation par défaut.',
+          ] },
           { type: 'tip' as const, text: 'L\'éditeur WYSIWYG supporte le gras, l\'italique, le souligné, les titres H2/H3, les listes à puces et numérotées.' },
         ],
       },

--- a/src/main/webui/src/pages/PalanqueePage.tsx
+++ b/src/main/webui/src/pages/PalanqueePage.tsx
@@ -701,15 +701,20 @@ export function PalanqueePage({ slotId, onBack }: Props) {
   // ── mail d'organisation ───────────────────────────────────────────────────
   const handleOpenMailModal = async () => {
     setMailSuccess(''); setMailError('');
-    // Charger le profil pour récupérer le modèle enregistré
+    // Charger le profil et la config admin pour récupérer le modèle
     let template = DpOrganizerMailer.DEFAULT_TEMPLATE;
     try {
-      const profile = await authService.getProfile();
+      const [profile, cfg] = await Promise.all([
+        authService.getProfile(),
+        adminService.getConfig().catch(() => null),
+      ]);
       if (profile.dpOrganizerEmailTemplate) template = profile.dpOrganizerEmailTemplate;
+      else if (cfg?.defaultOrganizerMailTemplate) template = cfg.defaultOrganizerMailTemplate;
     } catch { /* utiliser le modèle par défaut */ }
 
+    const titlePart = slot?.title?.trim();
     const defSubject = slot
-      ? `Organisation sortie du ${fmtDate(slot.slotDate)} — ${slot.title ?? slot.slotType ?? 'plongée'}`
+      ? `Organisation sortie du ${fmtDate(slot.slotDate)}${titlePart ? ` — ${titlePart}` : ''}`
       : 'Organisation de la sortie';
 
     setMailSubject(defSubject);

--- a/src/main/webui/src/pages/ProfilePage.tsx
+++ b/src/main/webui/src/pages/ProfilePage.tsx
@@ -40,7 +40,10 @@ export function ProfilePage() {
 
   // Charge le profil complet depuis l'API pour avoir phone & licenseNumber à jour
   useEffect(() => {
-    authService.getProfile().then(profile => {
+    Promise.all([
+      authService.getProfile(),
+      adminService.getConfig().catch(() => null),
+    ]).then(([profile, cfg]) => {
       setFirstName(profile.firstName || '');
       setLastName(profile.lastName   || '');
       setPhone(profile.phone || '');
@@ -53,9 +56,11 @@ export function ProfilePage() {
       setNotifOnDpRegistration(profile.notifOnDpRegistration ?? true);
       setNotifOnCreatorRegistration(profile.notifOnCreatorRegistration ?? false);
       setNotifOnSafetyReminder(profile.notifOnSafetyReminder ?? true);
-      const tpl = profile.dpOrganizerEmailTemplate || DpOrganizerMailer.DEFAULT_TEMPLATE;
+      const adminTpl = cfg?.defaultOrganizerMailTemplate ?? '';
+      const tpl = profile.dpOrganizerEmailTemplate || adminTpl || DpOrganizerMailer.DEFAULT_TEMPLATE;
       setDpTemplate(tpl);
       setDpTemplateKey(k => k + 1);
+      setClubs(cfg?.clubs ?? []);
     }).catch(() => {
       // Repli sur les données du contexte si l'API échoue
       setFirstName(user?.firstName || '');
@@ -64,7 +69,6 @@ export function ProfilePage() {
       setLicenseNumber(user?.licenseNumber || '');
       setClub(user?.club || '');
     });
-    adminService.getConfig().then(cfg => setClubs(cfg.clubs ?? [])).catch(() => {});
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/main/webui/src/services/adminService.ts
+++ b/src/main/webui/src/services/adminService.ts
@@ -154,6 +154,11 @@ export const adminService = {
     return res.data;
   },
 
+  async updateOrganizerMailTemplate(template: string): Promise<AppConfig> {
+    const res = await api.put<AppConfig>('/config/organizer-mail-template', { template });
+    return res.data;
+  },
+
   async sendManualReport(from: string, to: string, recipients: string, club?: string): Promise<{ count: number }> {
     const res = await api.post<{ count: number }>('/config/report-email-send', { fromDate: from, toDate: to, recipients, ...(club ? { club } : {}) });
     return res.data;

--- a/src/main/webui/src/types/index.ts
+++ b/src/main/webui/src/types/index.ts
@@ -169,6 +169,7 @@ export interface AppConfig {
   reportEmailPeriodDays: number;
   reportEmailRecipients: string;
   reportEmailLastSent: string;
+  defaultOrganizerMailTemplate?: string;
 }
 
 // Logs

--- a/src/test/java/org/santalina/diving/integration/ConfigResourceIT.java
+++ b/src/test/java/org/santalina/diving/integration/ConfigResourceIT.java
@@ -562,4 +562,39 @@ class ConfigResourceIT {
                 .statusCode(200)
                 .body("count", greaterThanOrEqualTo(0));
     }
+
+    /* ── Modèle d'e-mail d'organisation par défaut ── */
+
+    @Test
+    void updateOrganizerMailTemplate_shouldReturn401_withoutAuthentication() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"template\":\"<p>Test</p>\"}")
+                .when().put("/api/config/organizer-mail-template")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    @TestSecurity(user = "diver@test.com", roles = {"DIVER"})
+    void updateOrganizerMailTemplate_shouldReturn403_whenDiver() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"template\":\"<p>Test</p>\"}")
+                .when().put("/api/config/organizer-mail-template")
+                .then()
+                .statusCode(403);
+    }
+
+    @Test
+    @TestSecurity(user = "admin@santalina.com", roles = {"ADMIN"})
+    void updateOrganizerMailTemplate_shouldReturn200_andPersistTemplate_whenAdmin() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"template\":\"<p>Bonjour {dpName}</p>\"}")
+                .when().put("/api/config/organizer-mail-template")
+                .then()
+                .statusCode(200)
+                .body("defaultOrganizerMailTemplate", containsString("Bonjour"));
+    }
 }

--- a/src/test/java/org/santalina/diving/unit/DpOrganizerMailerTest.java
+++ b/src/test/java/org/santalina/diving/unit/DpOrganizerMailerTest.java
@@ -1,8 +1,12 @@
 package org.santalina.diving.unit;
 
 import org.junit.jupiter.api.Test;
+import org.santalina.diving.domain.DiveSlot;
 import org.santalina.diving.domain.User;
 import org.santalina.diving.mail.DpOrganizerMailer;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -17,6 +21,15 @@ class DpOrganizerMailerTest {
         u.lastName  = lastName;
         u.email     = email;
         return u;
+    }
+
+    private static DiveSlot slot(String title) {
+        DiveSlot s = new DiveSlot();
+        s.slotDate  = LocalDate.of(2025, 6, 14);
+        s.startTime = LocalTime.of(9, 0);
+        s.endTime   = LocalTime.of(12, 0);
+        s.title     = title;
+        return s;
     }
 
     @Test
@@ -55,5 +68,21 @@ class DpOrganizerMailerTest {
     void buildFromAddress_shouldReturnEmail_whenDpNull() {
         String from = DpOrganizerMailer.buildFromAddress(null, "solo@example.com");
         assertEquals("solo@example.com", from);
+    }
+
+    /* ── resolveVariables ── */
+
+    @Test
+    void resolveVariables_shouldIncludeSlotTitle_whenTitleIsSet() {
+        DiveSlot s = slot("Exploration");
+        String result = DpOrganizerMailer.resolveVariables("Sortie {slotTitle}", s, null, "Carrière");
+        assertEquals("Sortie Exploration", result);
+    }
+
+    @Test
+    void resolveVariables_shouldLeaveSlotTitleEmpty_whenTitleIsNull() {
+        DiveSlot s = slot(null);
+        String result = DpOrganizerMailer.resolveVariables("Sortie{slotTitle}", s, null, "Carrière");
+        assertEquals("Sortie", result);
     }
 }


### PR DESCRIPTION
…t sans titre

- Ajouter en admin (Référentiels) un éditeur WYSIWYG pour définir le modèle d'e-mail d'organisation par défaut, stocké en base via la clé "dp.organizer.mail.template.default". Fallback : template profil DP > template admin > template Java intégré.

- Corriger l'objet du mail : si le créneau n'a pas de titre, ne plus afficher le " — " suivi du type (ex: "Organisation sortie du 15/06/2024" au lieu de "Organisation sortie du 15/06/2024 — Exploration").

- Exposer PUT /api/config/organizer-mail-template (ADMIN uniquement).

- Mettre à jour ProfilePage et PalanqueePage pour consommer le modèle admin comme fallback entre le modèle du profil et le défaut intégré.

- Ajouter tests ConfigResourceIT (401/403/200) et DpOrganizerMailerTest (resolveVariables avec/sans slotTitle).

- Mettre à jour l'aide en ligne (section Mail, section Référentiels).