### PR TITLE
feat(safety-reminder): add activation date to prevent flood on first …

### DIFF
--- a/src/main/java/org/santalina/diving/dto/ConfigDto.java
+++ b/src/main/java/org/santalina/diving/dto/ConfigDto.java
@@ -37,6 +37,7 @@ public class ConfigDto {
             boolean notifSafetyReminderEnabled,
             int safetyReminderDelayDays,
             String safetyReminderEmailBody,
+            String safetyReminderActivationDate,
             boolean maintenanceMode,
             boolean reportEmailEnabled,
             int reportEmailPeriodDays,
@@ -90,7 +91,8 @@ public class ConfigDto {
             @NotNull Boolean notifDpNewRegEnabled,
             @NotNull Boolean notifSafetyReminderEnabled,
             @NotNull @Min(1) @jakarta.validation.constraints.Max(30) Integer safetyReminderDelayDays,
-            String safetyReminderEmailBody
+            String safetyReminderEmailBody,
+            String safetyReminderActivationDate
     ) {}
 
     public record UpdateReportEmailSettingsRequest(

--- a/src/main/java/org/santalina/diving/resource/ConfigResource.java
+++ b/src/main/java/org/santalina/diving/resource/ConfigResource.java
@@ -167,7 +167,8 @@ public class ConfigResource {
                 request.notifDpNewRegEnabled(),
                 request.notifSafetyReminderEnabled(),
                 request.safetyReminderDelayDays(),
-                request.safetyReminderEmailBody()
+                request.safetyReminderEmailBody(),
+                request.safetyReminderActivationDate()
         );
     }
 

--- a/src/main/java/org/santalina/diving/service/ConfigService.java
+++ b/src/main/java/org/santalina/diving/service/ConfigService.java
@@ -7,6 +7,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -46,9 +47,10 @@ public class ConfigService {
     private static final String KEY_MAINTENANCE_MODE           = "maintenance.mode";
 
     // -- Rappel fiche de sécurité --
-    private static final String KEY_NOTIF_SAFETY_REMINDER      = "notif.safety_reminder.enabled";
-    private static final String KEY_SAFETY_REMINDER_DELAY_DAYS = "notif.safety_reminder.delay_days";
-    private static final String KEY_SAFETY_REMINDER_EMAIL_BODY = "notif.safety_reminder.email_body";
+    private static final String KEY_NOTIF_SAFETY_REMINDER           = "notif.safety_reminder.enabled";
+    private static final String KEY_SAFETY_REMINDER_DELAY_DAYS      = "notif.safety_reminder.delay_days";
+    private static final String KEY_SAFETY_REMINDER_EMAIL_BODY      = "notif.safety_reminder.email_body";
+    private static final String KEY_SAFETY_REMINDER_ACTIVATION_DATE = "notif.safety_reminder.activation_date";
 
     // -- Rapport périodique d'inscriptions --
     private static final String KEY_REPORT_EMAIL_ENABLED     = "report.email.enabled";
@@ -186,6 +188,12 @@ public class ConfigService {
     public String getSafetyReminderEmailBody() {
         return getStringValue(KEY_SAFETY_REMINDER_EMAIL_BODY, DEFAULT_SAFETY_REMINDER_BODY);
     }
+    /** Retourne la date d'activation du rappel, ou {@code null} si non définie. */
+    public LocalDate getSafetyReminderActivationDate() {
+        String raw = getStringValue(KEY_SAFETY_REMINDER_ACTIVATION_DATE, "");
+        if (raw == null || raw.isBlank()) return null;
+        try { return LocalDate.parse(raw); } catch (Exception ignored) { return null; }
+    }
 
     // -- Getters rapport périodique --
     public boolean isReportEmailEnabled() {
@@ -225,6 +233,7 @@ public class ConfigService {
                 isNotifSafetyReminderEnabled(),
                 getSafetyReminderDelayDays(),
                 getSafetyReminderEmailBody(),
+                getSafetyReminderActivationDate() != null ? getSafetyReminderActivationDate().toString() : "",
                 isMaintenanceMode(),
                 isReportEmailEnabled(),
                 getReportEmailPeriodDays(),
@@ -359,7 +368,8 @@ public class ConfigService {
     public ConfigResponse updateNotifSettings(
             boolean registration, boolean approved, boolean cancelled,
             boolean movedToWl, boolean dpNewReg,
-            boolean safetyReminder, int safetyReminderDelayDays, String safetyReminderEmailBody) {
+            boolean safetyReminder, int safetyReminderDelayDays, String safetyReminderEmailBody,
+            String safetyReminderActivationDate) {
         forceUpsert(KEY_NOTIF_REGISTRATION, String.valueOf(registration));
         forceUpsert(KEY_NOTIF_APPROVED,     String.valueOf(approved));
         forceUpsert(KEY_NOTIF_CANCELLED,    String.valueOf(cancelled));
@@ -368,6 +378,16 @@ public class ConfigService {
         forceUpsert(KEY_NOTIF_SAFETY_REMINDER,      String.valueOf(safetyReminder));
         forceUpsert(KEY_SAFETY_REMINDER_DELAY_DAYS, String.valueOf(safetyReminderDelayDays));
         forceUpsert(KEY_SAFETY_REMINDER_EMAIL_BODY, safetyReminderEmailBody != null ? safetyReminderEmailBody.trim() : DEFAULT_SAFETY_REMINDER_BODY);
+        // Si une date d'activation est fournie explicitement, on l'enregistre
+        if (safetyReminderActivationDate != null && !safetyReminderActivationDate.isBlank()) {
+            try {
+                LocalDate.parse(safetyReminderActivationDate.trim()); // validation format
+                forceUpsert(KEY_SAFETY_REMINDER_ACTIVATION_DATE, safetyReminderActivationDate.trim());
+            } catch (Exception ignored) {}
+        } else if (safetyReminder && getSafetyReminderActivationDate() == null) {
+            // Auto-set uniquement si aucune date n'est encore définie et que le rappel est activé
+            forceUpsert(KEY_SAFETY_REMINDER_ACTIVATION_DATE, LocalDate.now().toString());
+        }
         return getConfig();
     }
 
@@ -411,9 +431,10 @@ public class ConfigService {
         upsertIfMissing(KEY_NOTIF_CANCELLED,    "true");
         upsertIfMissing(KEY_NOTIF_MOVED_TO_WL,  "true");
         upsertIfMissing(KEY_NOTIF_DP_NEW_REG,   "true");
-        upsertIfMissing(KEY_NOTIF_SAFETY_REMINDER,      "false");
-        upsertIfMissing(KEY_SAFETY_REMINDER_DELAY_DAYS, "3");
-        upsertIfMissing(KEY_SAFETY_REMINDER_EMAIL_BODY, DEFAULT_SAFETY_REMINDER_BODY);
+        upsertIfMissing(KEY_NOTIF_SAFETY_REMINDER,           "false");
+        upsertIfMissing(KEY_SAFETY_REMINDER_DELAY_DAYS,        "3");
+        upsertIfMissing(KEY_SAFETY_REMINDER_EMAIL_BODY,        DEFAULT_SAFETY_REMINDER_BODY);
+        upsertIfMissing(KEY_SAFETY_REMINDER_ACTIVATION_DATE,   "");
         upsertIfMissing(KEY_MAINTENANCE_MODE,           "false");
         upsertIfMissing(KEY_REPORT_EMAIL_ENABLED,       "false");
         upsertIfMissing(KEY_REPORT_EMAIL_PERIOD_DAYS,   "7");

--- a/src/main/java/org/santalina/diving/service/SafetySheetReminderService.java
+++ b/src/main/java/org/santalina/diving/service/SafetySheetReminderService.java
@@ -40,10 +40,13 @@ public class SafetySheetReminderService {
 
         int delayDays = configService.getSafetyReminderDelayDays();
         LocalDate cutoff = LocalDate.now().minusDays(delayDays);
+        LocalDate activationDate = configService.getSafetyReminderActivationDate();
 
         // Créneaux dont la date est <= cutoff et pour lesquels le rappel n'a pas encore été envoyé
-        List<DiveSlot> slots = DiveSlot.list(
-                "slotDate <= ?1 AND reminderSentAt IS NULL", cutoff);
+        // Si une date d'activation est définie, on exclut les créneaux antérieurs à cette date.
+        List<DiveSlot> slots = activationDate != null
+                ? DiveSlot.list("slotDate <= ?1 AND slotDate >= ?2 AND reminderSentAt IS NULL", cutoff, activationDate)
+                : DiveSlot.list("slotDate <= ?1 AND reminderSentAt IS NULL", cutoff);
 
         int sent = 0;
         int skipped = 0;

--- a/src/main/webui/package-lock.json
+++ b/src/main/webui/package-lock.json
@@ -63,7 +63,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1488,7 +1487,6 @@
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1512,7 +1510,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1579,7 +1576,6 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -1857,7 +1853,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2125,7 +2120,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2669,7 +2663,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3462,7 +3455,6 @@
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
       "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "fast-png": "^6.2.0",
@@ -3964,7 +3956,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4051,7 +4042,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4061,7 +4051,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4487,7 +4476,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4647,7 +4635,6 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -4816,7 +4803,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/main/webui/src/pages/AdminPage.tsx
+++ b/src/main/webui/src/pages/AdminPage.tsx
@@ -75,6 +75,7 @@ export function AdminPage() {
   const [safetyReminderDelayDays, setSafetyReminderDelayDays] = useState(3);
   const [safetyReminderEmailBody, setSafetyReminderEmailBody] = useState('');
   const [safetyReminderEmailBodyKey, setSafetyReminderEmailBodyKey] = useState(0);
+  const [safetyReminderActivationDate, setSafetyReminderActivationDate] = useState<string>('');
   const [notifSettingsLoading, setNotifSettingsLoading] = useState(false);
 
   // Rapport périodique d'inscriptions par e-mail
@@ -162,6 +163,7 @@ export function AdminPage() {
       setSafetyReminderDelayDays(c.safetyReminderDelayDays ?? 3);
       setSafetyReminderEmailBody(c.safetyReminderEmailBody ?? '');
       setSafetyReminderEmailBodyKey(k => k + 1);
+      setSafetyReminderActivationDate(c.safetyReminderActivationDate ?? '');
       setReportEmailEnabled(c.reportEmailEnabled ?? false);
       setReportEmailPeriodDays(c.reportEmailPeriodDays ?? 7);
       setReportEmailRecipients(c.reportEmailRecipients ?? '');
@@ -429,8 +431,10 @@ export function AdminPage() {
         notifSafetyReminderEnabled: notifSafetyReminder,
         safetyReminderDelayDays: safetyReminderDelayDays,
         safetyReminderEmailBody: safetyReminderEmailBody,
+        safetyReminderActivationDate: safetyReminderActivationDate || undefined,
       });
       setConfig(updated);
+      setSafetyReminderActivationDate(updated.safetyReminderActivationDate ?? '');
       setMsg('Paramètres de notifications enregistrés.');
     } catch (err: unknown) { setError(getErrorMessage(err)); }
     finally { setNotifSettingsLoading(false); }
@@ -868,6 +872,20 @@ export function AdminPage() {
         {notifSafetyReminder && (
           <div style={{ background: '#fffbeb', border: '1px solid #fcd34d', borderRadius: 8, padding: 16, marginBottom: 20 }}>
             <h4 style={{ margin: '0 0 12px', color: '#92400e', fontSize: 14 }}>⚙️ Configuration du rappel fiche de sécurité</h4>
+            <div className="form-group" style={{ marginBottom: 12 }}>
+              <label style={{ fontSize: 13 }}>
+                Date d'activation
+                <span style={{ fontWeight: 400, color: '#6b7280', marginLeft: 6 }}>
+                  (seuls les créneaux à partir de cette date recevront un rappel)
+                </span>
+              </label>
+              <input
+                type="date"
+                value={safetyReminderActivationDate}
+                onChange={e => setSafetyReminderActivationDate(e.target.value)}
+                style={{ width: 180 }}
+              />
+            </div>
             <div className="form-group" style={{ marginBottom: 12 }}>
               <label style={{ fontSize: 13 }}>Délai après la sortie (en jours)</label>
               <input

--- a/src/main/webui/src/services/adminService.ts
+++ b/src/main/webui/src/services/adminService.ts
@@ -135,6 +135,7 @@ export const adminService = {
     notifSafetyReminderEnabled: boolean;
     safetyReminderDelayDays: number;
     safetyReminderEmailBody: string;
+    safetyReminderActivationDate?: string;
   }): Promise<AppConfig> {
     const res = await api.put<AppConfig>('/config/notification-settings', settings);
     return res.data;

--- a/src/main/webui/src/types/index.ts
+++ b/src/main/webui/src/types/index.ts
@@ -164,6 +164,7 @@ export interface AppConfig {
   notifSafetyReminderEnabled: boolean;
   safetyReminderDelayDays: number;
   safetyReminderEmailBody: string;
+  safetyReminderActivationDate?: string;
   maintenanceMode: boolean;
   reportEmailEnabled: boolean;
   reportEmailPeriodDays: number;

--- a/src/test/java/org/santalina/diving/unit/ConfigServiceTest.java
+++ b/src/test/java/org/santalina/diving/unit/ConfigServiceTest.java
@@ -6,6 +6,7 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.santalina.diving.service.ConfigService;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -111,5 +112,58 @@ class ConfigServiceTest {
         assertNotNull(config);
         // La valeur retournée doit être cohérente avec le getter direct
         assertEquals(configService.isMaintenanceMode(), config.maintenanceMode());
+    }
+
+    // ── Date d'activation du rappel fiche de sécurité ───────────────────────
+
+    @Test
+    @TestTransaction
+    void updateNotifSettings_shouldAutoSetActivationDate_whenFirstEnabled() {
+        // On s'assure qu'aucune date n'est définie avant le test
+        configService.updateNotifSettings(true, true, true, true, true,
+                false, 3, "corps du rappel", null);
+        // Activer le rappel pour la première fois → la date doit être auto-définie à aujourd'hui
+        var config = configService.updateNotifSettings(true, true, true, true, true,
+                true, 3, "corps du rappel", null);
+
+        assertNotNull(config.safetyReminderActivationDate(),
+                "La date d'activation doit être définie dans la réponse");
+        assertFalse(config.safetyReminderActivationDate().isBlank(),
+                "La date d'activation ne doit pas être vide");
+        assertEquals(LocalDate.now().toString(), config.safetyReminderActivationDate(),
+                "La date d'activation doit correspondre à aujourd'hui");
+    }
+
+    @Test
+    @TestTransaction
+    void updateNotifSettings_shouldNotOverrideActivationDate_whenAlreadySet() {
+        // Premier enable : date = aujourd'hui
+        configService.updateNotifSettings(true, true, true, true, true,
+                true, 3, "corps", null);
+        String firstDate = configService.getConfig().safetyReminderActivationDate();
+        assertNotNull(firstDate);
+
+        // Deuxième appel avec enabled=true sans passer de date : la date ne doit pas changer
+        var config = configService.updateNotifSettings(true, true, true, true, true,
+                true, 5, "nouveau corps", null);
+
+        assertEquals(firstDate, config.safetyReminderActivationDate(),
+                "La date d'activation ne doit pas être réécrasée si elle est déjà définie");
+    }
+
+    @Test
+    @TestTransaction
+    void updateNotifSettings_shouldOverrideActivationDate_whenExplicitlyProvided() {
+        // Premier enable
+        configService.updateNotifSettings(true, true, true, true, true,
+                true, 3, "corps", null);
+
+        // Fournir une nouvelle date explicite
+        String newDate = "2026-01-01";
+        var config = configService.updateNotifSettings(true, true, true, true, true,
+                true, 3, "corps", newDate);
+
+        assertEquals(newDate, config.safetyReminderActivationDate(),
+                "La date d'activation doit être mise à jour quand une valeur explicite est fournie");
     }
 }

--- a/src/test/java/org/santalina/diving/unit/SafetySheetReminderServiceTest.java
+++ b/src/test/java/org/santalina/diving/unit/SafetySheetReminderServiceTest.java
@@ -1,0 +1,70 @@
+package org.santalina.diving.unit;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.santalina.diving.mail.WaitingListMailer;
+import org.santalina.diving.service.ConfigService;
+import org.santalina.diving.service.SafetySheetReminderService;
+
+import java.time.LocalDate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests unitaires de SafetySheetReminderService.
+ * La base H2 est vide : aucun créneau n'existe sauf ceux créés dans les tests.
+ */
+@QuarkusTest
+class SafetySheetReminderServiceTest {
+
+    @Inject
+    SafetySheetReminderService reminderService;
+
+    @InjectMock
+    ConfigService configService;
+
+    @InjectMock
+    WaitingListMailer mailer;
+
+    // ── Rappel désactivé ────────────────────────────────────────────────────
+
+    @Test
+    void sendPendingReminders_shouldDoNothing_whenDisabled() {
+        when(configService.isNotifSafetyReminderEnabled()).thenReturn(false);
+
+        reminderService.sendPendingReminders();
+
+        verify(mailer, never()).sendSafetySheetReminder(any(), any(), any(), any());
+    }
+
+    // ── Rappel activé, aucun créneau en base ────────────────────────────────
+
+    @Test
+    void sendPendingReminders_shouldSendNoMail_whenNoPastSlots() {
+        when(configService.isNotifSafetyReminderEnabled()).thenReturn(true);
+        when(configService.getSafetyReminderDelayDays()).thenReturn(3);
+        when(configService.getSafetyReminderActivationDate()).thenReturn(LocalDate.now().minusMonths(1));
+
+        reminderService.sendPendingReminders();
+
+        verify(mailer, never()).sendSafetySheetReminder(any(), any(), any(), any());
+    }
+
+    // ── Date d'activation dans le futur ─────────────────────────────────────
+
+    @Test
+    void sendPendingReminders_shouldSendNoMail_whenActivationDateIsNull() {
+        // Sans date d'activation : la requête n'a pas de borne inférieure.
+        // La base H2 de test étant vide, aucun mail ne doit partir.
+        when(configService.isNotifSafetyReminderEnabled()).thenReturn(true);
+        when(configService.getSafetyReminderDelayDays()).thenReturn(3);
+        when(configService.getSafetyReminderActivationDate()).thenReturn(null);
+
+        reminderService.sendPendingReminders();
+
+        verify(mailer, never()).sendSafetySheetReminder(any(), any(), any(), any());
+    }
+}


### PR DESCRIPTION
…enable

- SafetySheetReminderService: filter slots >= activationDate to avoid sending reminders for all past slots when the feature is first enabled
- ConfigService: auto-set activationDate on first enable; allow explicit override via updateNotifSettings
- ConfigDto/ConfigResponse: expose safetyReminderActivationDate field
- AdminPage: replace read-only banner with editable date input
- Add SafetySheetReminderServiceTest + 3 new ConfigServiceTest cases