### PR TITLE
feat(waiting-list): dossier incomplet → suppression de l'inscription

### DIFF
--- a/src/main/java/org/santalina/diving/config/DivingConfig.java
+++ b/src/main/java/org/santalina/diving/config/DivingConfig.java
@@ -46,4 +46,12 @@ public interface DivingConfig {
     @WithName("base-url")
     @WithDefault("http://localhost:8085")
     String baseUrl();
+
+    /**
+     * Répertoire racine pour le stockage des fichiers (pièces jointes, etc.).
+     * En production Docker, monté comme volume : {@code app_data:/deployments/data}.
+     */
+    @WithName("data-dir")
+    @WithDefault("./data")
+    String dataDir();
 }

--- a/src/main/java/org/santalina/diving/domain/DiveSlot.java
+++ b/src/main/java/org/santalina/diving/domain/DiveSlot.java
@@ -58,6 +58,13 @@ public class DiveSlot extends PanacheEntityBase {
     @Column(name = "reminder_sent_at")
     public LocalDateTime reminderSentAt;
 
+    /**
+     * Indique que ce créneau exige que les plongeurs auto-inscrits joignent
+     * leur certificat médical et le QR code de leur licence.
+     */
+    @Column(name = "requires_attachments", nullable = false)
+    public boolean requiresAttachments = false;
+
     @Column(name = "created_at", nullable = false)
     public LocalDateTime createdAt = LocalDateTime.now();
 

--- a/src/main/java/org/santalina/diving/domain/RegistrationStatus.java
+++ b/src/main/java/org/santalina/diving/domain/RegistrationStatus.java
@@ -1,0 +1,16 @@
+package org.santalina.diving.domain;
+
+/**
+ * Statut d'une inscription en liste d'attente.
+ *
+ * <ul>
+ *   <li>{@code PENDING_VERIFICATION} — inscription reçue, pièces jointes en attente de vérification par le DP.</li>
+ *   <li>{@code VERIFIED}             — le DP a validé les pièces jointes ; le plongeur est confirmé en L.A.</li>
+ *   <li>{@code INCOMPLETE}           — le DP a signalé un dossier incomplet ; l'inscription est annulée.</li>
+ * </ul>
+ */
+public enum RegistrationStatus {
+    PENDING_VERIFICATION,
+    VERIFIED,
+    INCOMPLETE
+}

--- a/src/main/java/org/santalina/diving/domain/WaitingListEntry.java
+++ b/src/main/java/org/santalina/diving/domain/WaitingListEntry.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.santalina.diving.domain.RegistrationStatus;
 
 /**
  * Entrée dans la liste d'attente pour l'auto-inscription sur un créneau.
@@ -65,6 +66,32 @@ public class WaitingListEntry extends PanacheEntityBase {
 
     @Column(name = "registered_at", nullable = false)
     public LocalDateTime registeredAt = LocalDateTime.now();
+
+    // ---- Pièces jointes & statut d'inscription ----
+
+    /**
+     * Statut de vérification du dossier par le DP.
+     * {@code PENDING_VERIFICATION} par défaut ; défini par le DP via l'endpoint dédié.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "registration_status", nullable = false, length = 30)
+    public RegistrationStatus registrationStatus = RegistrationStatus.PENDING_VERIFICATION;
+
+    /** Motif de rejet saisi par le DP (null si non renseigné). */
+    @Column(name = "rejection_reason", columnDefinition = "TEXT")
+    public String rejectionReason;
+
+    /** Chemin relatif (depuis le répertoire data) du certificat médical uploadé. */
+    @Column(name = "medical_cert_path", length = 500)
+    public String medicalCertPath;
+
+    /** Chemin relatif (depuis le répertoire data) du QR code de la licence uploadé. */
+    @Column(name = "license_qr_path", length = 500)
+    public String licenseQrPath;
+
+    /** Date/heure de suppression des pièces jointes (null = non supprimées). */
+    @Column(name = "attachments_deleted_at")
+    public LocalDateTime attachmentsDeletedAt;
 
     // ---- Panache finders ----
 

--- a/src/main/java/org/santalina/diving/dto/BackupDto.java
+++ b/src/main/java/org/santalina/diving/dto/BackupDto.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import org.santalina.diving.domain.RegistrationStatus;
 
 public class BackupDto {
 
@@ -63,7 +64,8 @@ public class BackupDto {
             Long createdById,
             LocalDateTime createdAt,
             boolean registrationOpen,
-            @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime registrationOpensAt
+            @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime registrationOpensAt,
+            boolean requiresAttachments
     ) {}
 
     public record DiverEntry(
@@ -107,7 +109,11 @@ public class BackupDto {
             LocalDateTime registeredAt,
             LocalDate medicalCertDate,
             boolean licenseConfirmed,
-            String club
+            String club,
+            RegistrationStatus registrationStatus,
+            String rejectionReason
+            // Note : medicalCertPath / licenseQrPath intentionnellement exclus
+            // (les fichiers ne sont pas sauvegardés dans le JSON)
     ) {}
 
     /** Réponse d'un import */

--- a/src/main/java/org/santalina/diving/dto/SlotDto.java
+++ b/src/main/java/org/santalina/diving/dto/SlotDto.java
@@ -60,7 +60,8 @@ public class SlotDto {
             List<SlotDiverResponse> divers,
             boolean registrationOpen,
             @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime registrationOpensAt,
-            long waitingListCount
+            long waitingListCount,
+            boolean requiresAttachments
     ) {
         public static SlotResponse from(DiveSlot slot) {
             List<SlotDiverResponse> divers = SlotDiver.findBySlot(slot.id)
@@ -81,7 +82,8 @@ public class SlotDto {
                     divers,
                     slot.registrationOpen,
                     slot.registrationOpensAt,
-                    waitingListCount
+                    waitingListCount,
+                    slot.requiresAttachments
             );
         }
     }

--- a/src/main/java/org/santalina/diving/dto/WaitingListDto.java
+++ b/src/main/java/org/santalina/diving/dto/WaitingListDto.java
@@ -1,9 +1,11 @@
 package org.santalina.diving.dto;
 
+import org.santalina.diving.domain.RegistrationStatus;
 import org.santalina.diving.domain.WaitingListEntry;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -66,7 +68,11 @@ public class WaitingListDto {
             LocalDate medicalCertDate,
             boolean licenseConfirmed,
             @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime registeredAt,
-            String club
+            String club,
+            RegistrationStatus registrationStatus,
+            String rejectionReason,
+            boolean hasMedicalCert,
+            boolean hasLicenseQr
     ) {
         public static WaitingListResponse from(WaitingListEntry e) {
             return new WaitingListResponse(
@@ -83,16 +89,30 @@ public class WaitingListDto {
                     e.medicalCertDate,
                     e.licenseConfirmed,
                     e.registeredAt,
-                    e.club
+                    e.club,
+                    e.registrationStatus,
+                    e.rejectionReason,
+                    e.medicalCertPath != null && e.attachmentsDeletedAt == null,
+                    e.licenseQrPath   != null && e.attachmentsDeletedAt == null
             );
         }
     }
+
+    /**
+     * Requête de mise à jour du statut d'une inscription (DP / ADMIN uniquement).
+     * Si {@code status} est {@code INCOMPLETE}, le champ {@code reason} est recommandé.
+     */
+    public record StatusUpdateRequest(
+            @NotNull RegistrationStatus status,
+            String reason
+    ) {}
 
     /**
      * Requête de mise à jour des paramètres d'inscription du créneau (DP uniquement).
      */
     public record UpdateRegistrationRequest(
             boolean registrationOpen,
-            @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime registrationOpensAt
+            @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime registrationOpensAt,
+            boolean requiresAttachments
     ) {}
 }

--- a/src/main/java/org/santalina/diving/mail/WaitingListMailer.java
+++ b/src/main/java/org/santalina/diving/mail/WaitingListMailer.java
@@ -339,6 +339,73 @@ public class WaitingListMailer {
         return true;
     }
 
+    // =========================================================================
+    // Mail au plongeur : dossier incomplet (DP a marqué INCOMPLETE)
+    // =========================================================================
+
+    public void sendRegistrationIncomplete(WaitingListEntry entry, DiveSlot slot, String reason) {
+        if (entry.email == null || entry.email.isBlank()) return;
+
+        String siteName  = configService.getSiteName();
+        String slotLabel = slotLabel(slot);
+        String subject   = "[" + siteName + "] Dossier incomplet \u2014 " + slotLabel;
+
+        String reasonBlock = (reason != null && !reason.isBlank())
+                ? "<p style=\"background:#fef3c7;border-left:4px solid #d97706;padding:12px 16px;margin:16px 0;\">"
+                  + "<strong>Motif :</strong> " + reason + "</p>"
+                : "";
+
+        String body = "<!DOCTYPE html>\n<html lang=\"fr\">\n<head>\n  <meta charset=\"UTF-8\" />\n  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" />\n</head>\n<body style=\"font-family:Arial,sans-serif;max-width:600px;margin:0 auto;\">"
+            + "<h2 style=\"color:#d97706;\">\u26a0\ufe0f Dossier incomplet</h2>"
+            + "<p>Bonjour <strong>" + entry.firstName + " " + entry.lastName + "</strong>,</p>"
+            + "<p>Le directeur de plong\u00e9e a examin\u00e9 votre dossier pour le cr\u00e9neau suivant "
+            + "et l'a marqu\u00e9 comme <strong>incomplet</strong>.</p>"
+            + "<table style=\"border-collapse:collapse;width:100%;margin:16px 0;\">"
+            + "<tr><td style=\"padding:4px 8px;color:#6b7280;\">Cr\u00e9neau :</td><td style=\"padding:4px 8px;\"><strong>" + slotLabel + "</strong></td></tr>"
+            + "<tr><td style=\"padding:4px 8px;color:#6b7280;\">Date :</td><td style=\"padding:4px 8px;\">" + slot.slotDate + "</td></tr>"
+            + "<tr><td style=\"padding:4px 8px;color:#6b7280;\">Horaire :</td><td style=\"padding:4px 8px;\">" + slot.startTime + " \u2013 " + slot.endTime + "</td></tr>"
+            + "</table>"
+            + reasonBlock
+            + "<p>Votre inscription a \u00e9t\u00e9 <strong>annul\u00e9e</strong>. Nous vous invitons \u00e0 vous r\u00e9inscrire avec un dossier complet si les inscriptions sont toujours ouvertes sur ce cr\u00e9neau.</p>"
+            + "<p style=\"color:#9ca3af;font-size:11px;margin-top:20px;\">\uD83D\uDCA1 Pour ne plus recevoir ce type de notification, <a href=\"" + config.baseUrl() + "/?goto=profile#notifications\" style=\"color:#9ca3af;\">modifiez vos pr\u00e9f\u00e9rences de notification</a> dans votre profil.</p>"
+            + "<hr style=\"border:1px solid #e5e7eb;margin-top:30px;\"/>"
+            + "<p style=\"color:#6b7280;font-size:12px;\">Syst\u00e8me de r\u00e9servation \u2014 " + siteName + "</p>"
+            + "</body></html>";
+
+        if (!shouldSend(configService.isNotifRegistrationEnabled(), "registration_incomplete", entry.email, subject, body)) return;
+        sendSingle(entry.email, subject, body);
+    }
+
+    // =========================================================================
+    // Mail au plongeur : dossier vérifié et validé (DP a marqué VERIFIED)
+    // =========================================================================
+
+    public void sendRegistrationVerified(WaitingListEntry entry, DiveSlot slot) {
+        if (entry.email == null || entry.email.isBlank()) return;
+
+        String siteName  = configService.getSiteName();
+        String slotLabel = slotLabel(slot);
+        String subject   = "[" + siteName + "] Dossier v\u00e9rifi\u00e9 \u2014 " + slotLabel;
+
+        String body = "<!DOCTYPE html>\n<html lang=\"fr\">\n<head>\n  <meta charset=\"UTF-8\" />\n  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" />\n</head>\n<body style=\"font-family:Arial,sans-serif;max-width:600px;margin:0 auto;\">"
+            + "<h2 style=\"color:#16a34a;\">\u2705 Dossier v\u00e9rifi\u00e9</h2>"
+            + "<p>Bonjour <strong>" + entry.firstName + " " + entry.lastName + "</strong>,</p>"
+            + "<p>Le directeur de plong\u00e9e a <strong>v\u00e9rifi\u00e9 et valid\u00e9</strong> votre dossier pour le cr\u00e9neau suivant.</p>"
+            + "<table style=\"border-collapse:collapse;width:100%;margin:16px 0;\">"
+            + "<tr><td style=\"padding:4px 8px;color:#6b7280;\">Cr\u00e9neau :</td><td style=\"padding:4px 8px;\"><strong>" + slotLabel + "</strong></td></tr>"
+            + "<tr><td style=\"padding:4px 8px;color:#6b7280;\">Date :</td><td style=\"padding:4px 8px;\">" + slot.slotDate + "</td></tr>"
+            + "<tr><td style=\"padding:4px 8px;color:#6b7280;\">Horaire :</td><td style=\"padding:4px 8px;\">" + slot.startTime + " \u2013 " + slot.endTime + "</td></tr>"
+            + "</table>"
+            + "<p>Votre demande reste enregistr\u00e9e. Le directeur de plong\u00e9e vous informera si votre place est confirm\u00e9e.</p>"
+            + "<p style=\"color:#9ca3af;font-size:11px;margin-top:20px;\">\uD83D\uDCA1 Pour ne plus recevoir ce type de notification, <a href=\"" + config.baseUrl() + "/?goto=profile#notifications\" style=\"color:#9ca3af;\">modifiez vos pr\u00e9f\u00e9rences de notification</a> dans votre profil.</p>"
+            + "<hr style=\"border:1px solid #e5e7eb;margin-top:30px;\"/>"
+            + "<p style=\"color:#6b7280;font-size:12px;\">Syst\u00e8me de r\u00e9servation \u2014 " + siteName + "</p>"
+            + "</body></html>";
+
+        if (!shouldSend(configService.isNotifRegistrationEnabled(), "registration_verified", entry.email, subject, body)) return;
+        sendSingle(entry.email, subject, body);
+    }
+
     private String slotLabel(DiveSlot slot) {
         return (slot.title != null && !slot.title.isBlank())
                 ? slot.title

--- a/src/main/java/org/santalina/diving/resource/AttachmentResource.java
+++ b/src/main/java/org/santalina/diving/resource/AttachmentResource.java
@@ -1,0 +1,131 @@
+package org.santalina.diving.resource;
+
+import org.santalina.diving.config.DivingConfig;
+import org.santalina.diving.domain.DiveSlot;
+import org.santalina.diving.domain.SlotDiver;
+import org.santalina.diving.domain.User;
+import org.santalina.diving.domain.WaitingListEntry;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+/**
+ * Endpoint pour télécharger les pièces jointes (certificat médical, QR code)
+ * associées à une entrée de la liste d'attente.
+ * <p>
+ * Accessible uniquement aux rôles {@code ADMIN} et {@code DIVE_DIRECTOR}
+ * (et uniquement si le DP est créateur ou DP assigné du créneau).
+ * </p>
+ */
+@Path("/api/attachments/{slotId}/{entryId}/{type}")
+@Tag(name = "Pièces jointes")
+public class AttachmentResource {
+
+    private static final Logger LOG = Logger.getLogger(AttachmentResource.class);
+
+    @Inject SecurityIdentity identity;
+    @Inject DivingConfig    divingConfig;
+
+    /**
+     * Retourne le fichier de la pièce jointe demandée.
+     *
+     * @param slotId  identifiant du créneau
+     * @param entryId identifiant de l'entrée dans la liste d'attente
+     * @param type    {@code medical-cert} ou {@code license-qr}
+     */
+    @GET
+    @RolesAllowed({"ADMIN", "DIVE_DIRECTOR"})
+    @Produces(MediaType.WILDCARD)
+    public Response download(@PathParam("slotId")  Long   slotId,
+                             @PathParam("entryId") Long   entryId,
+                             @PathParam("type")    String type) {
+
+        DiveSlot slot = DiveSlot.findById(slotId);
+        if (slot == null) throw new NotFoundException("Créneau non trouvé");
+
+        requireSlotOwnerOrAdmin(slot);
+
+        WaitingListEntry entry = WaitingListEntry.findById(entryId);
+        if (entry == null || !entry.slot.id.equals(slotId)) {
+            throw new NotFoundException("Entrée non trouvée dans la liste d'attente");
+        }
+
+        if (entry.attachmentsDeletedAt != null) {
+            return Response.status(410)
+                    .entity("{\"message\":\"Les pièces jointes de cette inscription ont été supprimées\"}")
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+        }
+
+        String relativePath = switch (type) {
+            case "medical-cert" -> entry.medicalCertPath;
+            case "license-qr"   -> entry.licenseQrPath;
+            default -> throw new NotFoundException("Type de pièce jointe inconnu : " + type);
+        };
+
+        if (relativePath == null || relativePath.isBlank()) {
+            throw new NotFoundException("Aucune pièce jointe de ce type pour cette inscription");
+        }
+
+        java.nio.file.Path file = Paths.get(divingConfig.dataDir()).resolve(relativePath);
+        if (!Files.exists(file)) {
+            LOG.warnf("Fichier introuvable sur le disque : %s", file);
+            throw new NotFoundException("Fichier introuvable");
+        }
+
+        String contentType = detectContentType(file);
+
+        try {
+            byte[] bytes = Files.readAllBytes(file);
+            return Response.ok(bytes)
+                    .header("Content-Type",        contentType)
+                    .header("Content-Disposition", "inline; filename=\"" + file.getFileName() + "\"")
+                    .build();
+        } catch (IOException e) {
+            LOG.errorf(e, "Erreur lors de la lecture du fichier %s", file);
+            throw new InternalServerErrorException("Impossible de lire le fichier");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private void requireSlotOwnerOrAdmin(DiveSlot slot) {
+        var roles = identity.getRoles();
+        String role = (roles != null && !roles.isEmpty()) ? roles.iterator().next() : "";
+        if ("ADMIN".equals(role)) return;
+        if ("DIVE_DIRECTOR".equals(role)) {
+            User current = User.findByEmail(identity.getPrincipal().getName());
+            if (current != null) {
+                boolean isCreator    = slot.createdBy != null && slot.createdBy.id.equals(current.id);
+                boolean isAssignedDP = SlotDiver.isAssignedDirectorByEmail(slot.id, current.email);
+                if (isCreator || isAssignedDP) return;
+            }
+        }
+        throw new ForbiddenException("Accès réservé au directeur de plongée du créneau");
+    }
+
+    private static String detectContentType(java.nio.file.Path file) {
+        String name = file.getFileName().toString().toLowerCase();
+        if (name.endsWith(".pdf"))  return "application/pdf";
+        if (name.endsWith(".png"))  return "image/png";
+        if (name.endsWith(".webp")) return "image/webp";
+        return "image/jpeg";
+    }
+}

--- a/src/main/java/org/santalina/diving/resource/WaitingListResource.java
+++ b/src/main/java/org/santalina/diving/resource/WaitingListResource.java
@@ -1,14 +1,18 @@
 package org.santalina.diving.resource;
 
+import org.santalina.diving.config.DivingConfig;
 import org.santalina.diving.domain.DiveSlot;
+import org.santalina.diving.domain.RegistrationStatus;
 import org.santalina.diving.domain.SlotDiver;
 import org.santalina.diving.domain.User;
 import org.santalina.diving.domain.WaitingListEntry;
 import org.santalina.diving.dto.SlotDiverDto.SlotDiverRequest;
+import org.santalina.diving.dto.WaitingListDto.StatusUpdateRequest;
 import org.santalina.diving.dto.WaitingListDto.WaitingListRequest;
 import org.santalina.diving.dto.WaitingListDto.WaitingListResponse;
 import org.santalina.diving.mail.WaitingListMailer;
 import org.santalina.diving.service.DelayedNotificationService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.security.PermitAll;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
@@ -19,8 +23,16 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import io.quarkus.security.identity.SecurityIdentity;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.multipart.FileUpload;
 import org.santalina.diving.security.NameUtil;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -31,99 +43,141 @@ import java.util.List;
  *   <li>POST  — inscription d'un plongeur authentifié (DIVER)</li>
  *   <li>GET   — lecture de la liste (DP du créneau ou ADMIN)</li>
  *   <li>POST  /{entryId}/approve — validation → transfert dans slot_divers</li>
+ *   <li>PATCH /{entryId}/status — mise à jour du statut de vérification (DP/ADMIN)</li>
  *   <li>DELETE/{entryId} — annulation par le plongeur lui-même ou par le DP/ADMIN</li>
  * </ul>
  */
 @Path("/api/slots/{slotId}/waiting-list")
 @Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 @Tag(name = "Liste d'attente")
 public class WaitingListResource {
 
-    @Inject
-    SecurityIdentity identity;
+    private static final Logger LOG = Logger.getLogger(WaitingListResource.class);
 
-    @Inject
-    WaitingListMailer mailer;
+    /** Extensions de fichier autorisées pour les pièces jointes. */
+    private static final List<String> ALLOWED_EXTENSIONS = List.of("jpg", "jpeg", "png", "pdf", "webp");
+    /** Taille maximale d'un fichier joint : 5 Mo. */
+    private static final long MAX_FILE_SIZE = 5 * 1024 * 1024;
 
-    @Inject
-    DelayedNotificationService delayedNotif;
+    @Inject SecurityIdentity identity;
+    @Inject WaitingListMailer mailer;
+    @Inject DelayedNotificationService delayedNotif;
+    @Inject DivingConfig divingConfig;
+    @Inject ObjectMapper objectMapper;
 
     // -------------------------------------------------------------------------
-    // Inscription (plongeur authentifié)
+    // Inscription (plongeur authentifié)  — multipart quand pièces jointes requises
     // -------------------------------------------------------------------------
 
+    /**
+     * Inscription JSON simple (créneau sans pièces jointes obligatoires).
+     */
     @POST
     @Transactional
+    @Consumes(MediaType.APPLICATION_JSON)
     @RolesAllowed({"DIVER", "DIVE_DIRECTOR", "ADMIN"})
     public Response register(@PathParam("slotId") Long slotId,
                              @Valid WaitingListRequest request) {
+        return doRegister(slotId, request, null, null);
+    }
 
+    /**
+     * Inscription multipart (créneau avec pièces jointes obligatoires).
+     * Le champ {@code data} contient le JSON de {@link WaitingListRequest}.
+     */
+    @POST
+    @Path("/with-attachments")
+    @Transactional
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @RolesAllowed({"DIVER", "DIVE_DIRECTOR", "ADMIN"})
+    public Response registerWithAttachments(
+            @PathParam("slotId") Long slotId,
+            @RestForm("data")    String dataJson,
+            @RestForm("medicalCert") FileUpload medicalCert,
+            @RestForm("licenseQr")   FileUpload licenseQr) throws IOException {
+
+        WaitingListRequest request;
+        try {
+            request = objectMapper.readValue(dataJson, WaitingListRequest.class);
+        } catch (Exception e) {
+            throw new BadRequestException("Le champ 'data' n'est pas un JSON valide : " + e.getMessage());
+        }
+
+        validateUpload(medicalCert, "certificat médical");
+        validateUpload(licenseQr,   "QR code de la licence");
+
+        return doRegister(slotId, request, medicalCert, licenseQr);
+    }
+
+    private Response doRegister(Long slotId, WaitingListRequest request,
+                                 FileUpload medicalCert, FileUpload licenseQr) {
         DiveSlot slot = DiveSlot.findById(slotId);
         if (slot == null) throw new NotFoundException("Créneau non trouvé");
 
-        // Vérifier que le DP a bien assigné un directeur de plongée sur le créneau
         if (!SlotDiver.hasDirector(slotId)) {
             throw new BadRequestException("Ce créneau n'a pas encore de directeur de plongée — les inscriptions libres ne sont pas disponibles");
         }
-
-        // Vérifier que les inscriptions sont ouvertes
         if (!slot.registrationOpen) {
             throw new BadRequestException("Les inscriptions libres ne sont pas activées sur ce créneau");
         }
-
-        // Vérifier la date d'ouverture
         if (slot.registrationOpensAt != null && LocalDateTime.now().isBefore(slot.registrationOpensAt)) {
             throw new BadRequestException("Les inscriptions ouvrent le " + slot.registrationOpensAt.toLocalDate()
                     + " à " + slot.registrationOpensAt.toLocalTime());
         }
 
-        // Vérifier que le plongeur confirme sa licence FFESSM
+        // Vérifier les pièces jointes si requises
+        if (slot.requiresAttachments && (medicalCert == null || licenseQr == null)) {
+            throw new BadRequestException("Ce créneau exige le certificat médical et le QR code de la licence FFESSM");
+        }
+
         if (!Boolean.TRUE.equals(request.licenseConfirmed())) {
             throw new BadRequestException("Vous devez confirmer la validité de votre licence FFESSM");
         }
-
-        // Vérifier la date du certificat médical
         if (request.medicalCertDate() == null) {
             throw new BadRequestException("La date de début de votre certificat médical est obligatoire");
         }
         if (request.medicalCertDate().isBefore(slot.slotDate.minusYears(1))) {
             throw new BadRequestException("Votre certificat médical est expiré (plus d'un an avant la date du créneau)");
         }
-
-        // Vérifier la double saisie email
         if (!request.email().equalsIgnoreCase(request.emailConfirm())) {
             throw new BadRequestException("Les deux adresses e-mail ne correspondent pas");
         }
-
-        // Vérifier qu'on n'est pas déjà dans la liste d'attente
         if (WaitingListEntry.existsBySlotAndEmail(slotId, request.email())) {
             throw new BadRequestException("Vous êtes déjà inscrit(e) sur la liste d'attente de ce créneau");
         }
-
-        // Vérifier qu'on n'est pas déjà validé (slot_divers)
         if (existsDiverByEmail(slotId, request.email())) {
             throw new BadRequestException("Vous êtes déjà inscrit(e) comme plongeur sur ce créneau");
         }
 
         WaitingListEntry entry = new WaitingListEntry();
-        entry.slot          = slot;
-        entry.firstName     = NameUtil.capitalize(request.firstName().trim());
-        entry.lastName      = request.lastName().trim().toUpperCase();
-        entry.email         = request.email().trim().toLowerCase();
-        entry.level         = request.level();
-        entry.numberOfDives = request.numberOfDives();
-        entry.lastDiveDate  = request.lastDiveDate();
-        entry.preparedLevel = request.preparedLevel();
-        entry.comment       = request.comment();
+        entry.slot             = slot;
+        entry.firstName        = NameUtil.capitalize(request.firstName().trim());
+        entry.lastName         = request.lastName().trim().toUpperCase();
+        entry.email            = request.email().trim().toLowerCase();
+        entry.level            = request.level();
+        entry.numberOfDives    = request.numberOfDives();
+        entry.lastDiveDate     = request.lastDiveDate();
+        entry.preparedLevel    = request.preparedLevel();
+        entry.comment          = request.comment();
         entry.medicalCertDate  = request.medicalCertDate();
         entry.licenseConfirmed = Boolean.TRUE.equals(request.licenseConfirmed());
         entry.club             = request.club();
-        entry.persist();
+        entry.persist();  // flush pour obtenir l'id avant de stocker les fichiers
+
+        // Persister les pièces jointes si fournies
+        if (medicalCert != null) {
+            String path = saveAttachmentFile(medicalCert, slotId, entry.id, "medical_cert");
+            entry.medicalCertPath = path;
+        }
+        if (licenseQr != null) {
+            String path = saveAttachmentFile(licenseQr, slotId, entry.id, "license_qr");
+            entry.licenseQrPath = path;
+        }
+        if (medicalCert != null || licenseQr != null) {
+            entry.persist();
+        }
 
         mailer.sendWaitingListConfirmation(entry, slot);
-
-        // Notifier le DP assigné et le créateur du créneau (séparément pour les préférences)
         for (OwnerRef owner : resolveOwnerRefs(slot)) {
             mailer.sendNewRegistrationToDP(entry, slot, owner.email(), owner.isAssignedDp());
         }
@@ -135,9 +189,9 @@ public class WaitingListResource {
     // Lecture de la liste (DP du créneau ou ADMIN)
     // -------------------------------------------------------------------------
 
-    // GET /me — entrée de l'utilisateur connecté pour ce créneau (tout rôle authentifié)
     @GET
     @Path("/me")
+    @Consumes(MediaType.APPLICATION_JSON)
     @RolesAllowed({"DIVER", "DIVE_DIRECTOR", "ADMIN"})
     public Response getMyEntry(@PathParam("slotId") Long slotId) {
         DiveSlot slot = DiveSlot.findById(slotId);
@@ -150,9 +204,9 @@ public class WaitingListResource {
         }
         return Response.ok(WaitingListResponse.from(entry)).build();
     }
-    // -------------------------------------------------------------------------
 
     @GET
+    @Consumes(MediaType.APPLICATION_JSON)
     @RolesAllowed({"ADMIN", "DIVE_DIRECTOR"})
     public List<WaitingListResponse> getWaitingList(@PathParam("slotId") Long slotId) {
         DiveSlot slot = DiveSlot.findById(slotId);
@@ -166,12 +220,55 @@ public class WaitingListResource {
     }
 
     // -------------------------------------------------------------------------
+    // Mise à jour du statut de vérification (DP / ADMIN)
+    // -------------------------------------------------------------------------
+
+    @PATCH
+    @Path("/{entryId}/status")
+    @Transactional
+    @Consumes(MediaType.APPLICATION_JSON)
+    @RolesAllowed({"ADMIN", "DIVE_DIRECTOR"})
+    public Response updateStatus(@PathParam("slotId") Long slotId,
+                                 @PathParam("entryId") Long entryId,
+                                 @Valid StatusUpdateRequest request) {
+        DiveSlot slot = DiveSlot.findById(slotId);
+        if (slot == null) throw new NotFoundException("Créneau non trouvé");
+        requireSlotOwnerOrAdmin(slot);
+
+        WaitingListEntry entry = WaitingListEntry.findById(entryId);
+        if (entry == null || !entry.slot.id.equals(slotId)) {
+            throw new NotFoundException("Entrée non trouvée dans la liste d'attente");
+        }
+
+        if (request.status() == RegistrationStatus.INCOMPLETE) {
+            // Envoyer l'email AVANT de supprimer l'entrée (pour avoir accès aux données)
+            mailer.sendRegistrationIncomplete(entry, slot, request.reason());
+            // Supprimer les fichiers joints
+            deleteAttachmentFiles(entry);
+            // Supprimer l'entrée — le plongeur devra se réinscrire
+            entry.delete();
+            return Response.status(Response.Status.NO_CONTENT).build();
+        }
+
+        entry.registrationStatus = request.status();
+        entry.rejectionReason    = request.reason();
+        entry.persist();
+
+        if (request.status() == RegistrationStatus.VERIFIED) {
+            mailer.sendRegistrationVerified(entry, slot);
+        }
+
+        return Response.ok(WaitingListResponse.from(entry)).build();
+    }
+
+    // -------------------------------------------------------------------------
     // Validation (DP uniquement) — transfert vers slot_divers
     // -------------------------------------------------------------------------
 
     @POST
     @Path("/{entryId}/approve")
     @Transactional
+    @Consumes(MediaType.APPLICATION_JSON)
     @RolesAllowed({"ADMIN", "DIVE_DIRECTOR"})
     public Response approve(@PathParam("slotId") Long slotId,
                             @PathParam("entryId") Long entryId) {
@@ -185,35 +282,31 @@ public class WaitingListResource {
             throw new NotFoundException("Entrée non trouvée dans la liste d'attente");
         }
 
-        // Vérifier capacité
         long current = SlotDiver.countBySlot(slotId);
         if (current >= slot.diverCount) {
             throw new BadRequestException("Le créneau est complet (" + slot.diverCount + " plongeurs max)");
         }
-
-        // Vérifier doublon nom
         if (SlotDiver.existsBySlotAndName(slotId, entry.firstName, entry.lastName)) {
             throw new BadRequestException("Un plongeur avec ce nom est déjà inscrit sur ce créneau");
         }
 
-        // Transférer dans slot_divers
         SlotDiver diver = new SlotDiver();
-        diver.slot          = slot;
-        diver.firstName     = entry.firstName;
-        diver.lastName      = entry.lastName;
-        diver.level         = entry.level;
-        diver.email         = entry.email;
-        diver.isDirector    = false;
-        diver.aptitudes     = null;  // preparedLevel est informatif uniquement, pas pré-rempli dans les aptitudes
+        diver.slot           = slot;
+        diver.firstName      = entry.firstName;
+        diver.lastName       = entry.lastName;
+        diver.level          = entry.level;
+        diver.email          = entry.email;
+        diver.isDirector     = false;
+        diver.aptitudes      = null;
         diver.medicalCertDate = entry.medicalCertDate;
         diver.comment        = entry.comment;
         diver.club           = entry.club;
         diver.persist();
 
-        // Planifier l'envoi du mail de validation avec le délai de grâce (15 min)
         delayedNotif.scheduleApprovedMail(slotId, entry.email, entry.firstName, entry.lastName);
 
-        // Supprimer de la liste d'attente
+        // Supprimer les fichiers attachés avant de supprimer l'entrée
+        deleteAttachmentFiles(entry);
         entry.delete();
 
         return Response.ok(org.santalina.diving.dto.SlotDiverDto.SlotDiverResponse.from(diver)).build();
@@ -226,6 +319,7 @@ public class WaitingListResource {
     @DELETE
     @Path("/{entryId}")
     @Transactional
+    @Consumes(MediaType.APPLICATION_JSON)
     @RolesAllowed({"DIVER", "DIVE_DIRECTOR", "ADMIN"})
     public Response cancel(@PathParam("slotId") Long slotId,
                            @PathParam("entryId") Long entryId) {
@@ -240,30 +334,28 @@ public class WaitingListResource {
         String callerEmail = identity.getPrincipal().getName();
         String role        = getRole();
 
-        boolean isAdmin = "ADMIN".equals(role);
-        boolean isSlotOwner = "DIVE_DIRECTOR".equals(role)
+        boolean isAdmin      = "ADMIN".equals(role);
+        boolean isSlotOwner  = "DIVE_DIRECTOR".equals(role)
                 && slot.createdBy != null
                 && slot.createdBy.email.equalsIgnoreCase(callerEmail);
-        boolean isDiver = entry.email.equalsIgnoreCase(callerEmail);
+        boolean isDiver      = entry.email.equalsIgnoreCase(callerEmail);
 
         if (!isAdmin && !isSlotOwner && !isDiver) {
             throw new ForbiddenException("Vous n'êtes pas autorisé(e) à annuler cette inscription");
         }
 
-        // Envoyer mail au DP et au créateur si c'est le plongeur qui annule
         if (isDiver && !isAdmin && !isSlotOwner) {
             for (OwnerRef owner : resolveOwnerRefs(slot)) {
                 mailer.sendCancellationToDP(entry, slot, owner.email(), owner.isAssignedDp());
             }
         }
-
-        // Envoyer mail au plongeur si c'est le DP ou l'admin qui annule
         if ((isAdmin || isSlotOwner) && !isDiver) {
             if (entry.email != null && !entry.email.isBlank()) {
                 mailer.sendCancellationToDiver(entry.email, entry.firstName, entry.lastName, slot);
             }
         }
 
+        deleteAttachmentFiles(entry);
         entry.delete();
         return Response.noContent().build();
     }
@@ -272,14 +364,80 @@ public class WaitingListResource {
     // Helpers
     // -------------------------------------------------------------------------
 
-    /** Vérifie que le caller est propriétaire du créneau ou son DP assigné ou ADMIN. Lève 403 sinon. */
+    private void validateUpload(FileUpload upload, String label) {
+        if (upload == null || upload.uploadedFile() == null) {
+            throw new BadRequestException("Le fichier '" + label + "' est manquant");
+        }
+        if (upload.size() > MAX_FILE_SIZE) {
+            throw new BadRequestException("Le fichier '" + label + "' dépasse la taille maximale autorisée (5 Mo)");
+        }
+        String ext = getExtension(upload.fileName());
+        if (!ALLOWED_EXTENSIONS.contains(ext.toLowerCase())) {
+            throw new BadRequestException("Le fichier '" + label + "' doit être une image (JPG, PNG, WEBP) ou un PDF");
+        }
+    }
+
+    /**
+     * Enregistre un fichier uploadé et retourne son chemin relatif au répertoire data.
+     * Chemin : {@code attachments/waiting-list/{slotId}/{entryId}/{baseName}.{ext}}
+     */
+    private String saveAttachmentFile(FileUpload upload, Long slotId, Long entryId, String baseName) {
+        String ext = getExtension(upload.fileName());
+        String relativePath = "attachments/waiting-list/" + slotId + "/" + entryId + "/" + baseName + "." + ext;
+        java.nio.file.Path target = Paths.get(divingConfig.dataDir()).resolve(relativePath);
+        try {
+            Files.createDirectories(target.getParent());
+            try (InputStream in = Files.newInputStream(upload.uploadedFile())) {
+                Files.copy(in, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (IOException e) {
+            LOG.errorf(e, "Impossible de sauvegarder le fichier %s", target);
+            throw new InternalServerErrorException("Erreur lors de la sauvegarde du fichier joint");
+        }
+        return relativePath;
+    }
+
+    /** Supprime les fichiers attachés d'une entrée de la liste d'attente. */
+    private void deleteAttachmentFiles(WaitingListEntry entry) {
+        deleteFileIfExists(entry.medicalCertPath);
+        deleteFileIfExists(entry.licenseQrPath);
+        // Essayer de supprimer le répertoire parent s'il est vide
+        if (entry.medicalCertPath != null) {
+            try {
+                java.nio.file.Path dir = Paths.get(divingConfig.dataDir())
+                        .resolve(entry.medicalCertPath).getParent();
+                if (dir != null && Files.isDirectory(dir)) {
+                    try (var stream = Files.list(dir)) {
+                        if (stream.findAny().isEmpty()) Files.delete(dir);
+                    }
+                }
+            } catch (IOException ignored) {}
+        }
+    }
+
+    private void deleteFileIfExists(String relativePath) {
+        if (relativePath == null || relativePath.isBlank()) return;
+        try {
+            java.nio.file.Path p = Paths.get(divingConfig.dataDir()).resolve(relativePath);
+            Files.deleteIfExists(p);
+        } catch (IOException e) {
+            LOG.warnf("Impossible de supprimer le fichier %s : %s", relativePath, e.getMessage());
+        }
+    }
+
+    private static String getExtension(String filename) {
+        if (filename == null) return "";
+        int dot = filename.lastIndexOf('.');
+        return (dot >= 0 && dot < filename.length() - 1) ? filename.substring(dot + 1) : "";
+    }
+
     private void requireSlotOwnerOrAdmin(DiveSlot slot) {
         String role = getRole();
         if ("ADMIN".equals(role)) return;
         if ("DIVE_DIRECTOR".equals(role)) {
             User current = User.findByEmail(identity.getPrincipal().getName());
             if (current != null) {
-                boolean isCreator = slot.createdBy != null && slot.createdBy.id.equals(current.id);
+                boolean isCreator    = slot.createdBy != null && slot.createdBy.id.equals(current.id);
                 boolean isAssignedDP = SlotDiver.isAssignedDirectorByEmail(slot.id, current.email);
                 if (isCreator || isAssignedDP) return;
             }
@@ -287,38 +445,28 @@ public class WaitingListResource {
         throw new ForbiddenException("Accès réservé au directeur de plongée du créneau");
     }
 
-    /** Retourne le rôle du JWT. */
     private String getRole() {
         var roles = identity.getRoles();
         return (roles != null && !roles.isEmpty()) ? roles.iterator().next() : "";
     }
 
-    /** Référence à un propriétaire du créneau (DP assigné et/ou créateur) */
     private record OwnerRef(String email, boolean isAssignedDp) {}
 
-    /** Retourne les propriétaires du créneau (DP assigné et créateur) avec leur rôle. */
     private List<OwnerRef> resolveOwnerRefs(DiveSlot slot) {
         List<OwnerRef> owners = new ArrayList<>();
-
         SlotDiver dp = SlotDiver.<SlotDiver>find("slot.id = ?1 and isDirector = true", slot.id).firstResult();
         String dpEmail = (dp != null && dp.email != null && !dp.email.isBlank())
                 ? dp.email.toLowerCase() : null;
-        if (dpEmail != null) {
-            owners.add(new OwnerRef(dpEmail, true));
-        }
+        if (dpEmail != null) owners.add(new OwnerRef(dpEmail, true));
 
         if (slot.createdBy != null && slot.createdBy.email != null && !slot.createdBy.email.isBlank()) {
             String creatorEmail = slot.createdBy.email.toLowerCase();
-            if (!creatorEmail.equals(dpEmail)) {
-                owners.add(new OwnerRef(creatorEmail, false));
-            }
+            if (!creatorEmail.equals(dpEmail)) owners.add(new OwnerRef(creatorEmail, false));
         }
         return owners;
     }
 
-    /** Vérifie si un email est déjà présent dans slot_divers pour ce créneau. */
     private boolean existsDiverByEmail(Long slotId, String email) {
-        return SlotDiver.count(
-                "slot.id = ?1 and lower(email) = lower(?2)", slotId, email) > 0;
+        return SlotDiver.count("slot.id = ?1 and lower(email) = lower(?2)", slotId, email) > 0;
     }
 }

--- a/src/main/java/org/santalina/diving/service/AttachmentCleanupService.java
+++ b/src/main/java/org/santalina/diving/service/AttachmentCleanupService.java
@@ -1,0 +1,117 @@
+package org.santalina.diving.service;
+
+import io.quarkus.scheduler.Scheduled;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.jboss.logging.Logger;
+import org.santalina.diving.config.DivingConfig;
+import org.santalina.diving.domain.WaitingListEntry;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Suppression automatique des pièces jointes (certificat médical, QR code de la licence)
+ * liées aux inscriptions en liste d'attente, une semaine après la date du créneau.
+ *
+ * <p>Planifié chaque nuit à 02h00. Seules les entrées dont le créneau date
+ * d'au moins 7 jours et dont les pièces jointes n'ont pas encore été supprimées
+ * sont traitées.</p>
+ */
+@ApplicationScoped
+public class AttachmentCleanupService {
+
+    private static final Logger LOG = Logger.getLogger(AttachmentCleanupService.class);
+
+    @Inject DivingConfig divingConfig;
+
+    /**
+     * Supprime les pièces jointes pour les créneaux dont la date est
+     * antérieure d'au moins 7 jours à aujourd'hui.
+     */
+    @Scheduled(cron = "0 0 2 * * ?")
+    @Transactional
+    public void cleanupOldAttachments() {
+        LocalDate cutoff = LocalDate.now().minusDays(7);
+
+        List<WaitingListEntry> entries = WaitingListEntry.list(
+                "slot.slotDate <= ?1 AND attachmentsDeletedAt IS NULL "
+                        + "AND (medicalCertPath IS NOT NULL OR licenseQrPath IS NOT NULL)",
+                cutoff);
+
+        if (entries.isEmpty()) {
+            LOG.debug("Aucune pièce jointe à nettoyer");
+            return;
+        }
+
+        LOG.infof("Nettoyage des pièces jointes : %d entrée(s) concernée(s) (cutoff=%s)", entries.size(), cutoff);
+
+        for (WaitingListEntry entry : entries) {
+            deleteFileIfExists(entry.medicalCertPath);
+            deleteFileIfExists(entry.licenseQrPath);
+
+            // Supprimer le répertoire de l'entrée s'il est vide
+            deleteEmptyEntryDir(entry);
+
+            entry.medicalCertPath        = null;
+            entry.licenseQrPath          = null;
+            entry.attachmentsDeletedAt   = LocalDateTime.now();
+            entry.persist();
+        }
+
+        LOG.infof("Nettoyage terminé : %d pièce(s) jointe(s) supprimée(s)", entries.size());
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private void deleteFileIfExists(String relativePath) {
+        if (relativePath == null || relativePath.isBlank()) return;
+        try {
+            Path p = Paths.get(divingConfig.dataDir()).resolve(relativePath);
+            boolean deleted = Files.deleteIfExists(p);
+            if (deleted) {
+                LOG.debugf("Fichier supprimé : %s", p);
+            }
+        } catch (IOException e) {
+            LOG.warnf("Impossible de supprimer %s : %s", relativePath, e.getMessage());
+        }
+    }
+
+    private void deleteEmptyEntryDir(WaitingListEntry entry) {
+        String anyPath = entry.medicalCertPath != null ? entry.medicalCertPath : entry.licenseQrPath;
+        if (anyPath == null) return;
+        try {
+            Path entryDir = Paths.get(divingConfig.dataDir()).resolve(anyPath).getParent();
+            if (entryDir == null) return;
+
+            // Supprimer le répertoire de l'entrée ({entryId}/) s'il est vide
+            deleteIfEmpty(entryDir);
+
+            // Supprimer le répertoire du créneau ({slotId}/) s'il est vide
+            Path slotDir = entryDir.getParent();
+            if (slotDir != null) {
+                deleteIfEmpty(slotDir);
+            }
+        } catch (IOException e) {
+            LOG.warnf("Impossible de supprimer le répertoire vide : %s", e.getMessage());
+        }
+    }
+
+    private void deleteIfEmpty(Path dir) throws IOException {
+        if (!Files.isDirectory(dir)) return;
+        try (var stream = Files.list(dir)) {
+            if (stream.findAny().isEmpty()) {
+                Files.delete(dir);
+                LOG.debugf("Répertoire vide supprimé : %s", dir);
+            }
+        }
+    }
+}

--- a/src/main/java/org/santalina/diving/service/BackupService.java
+++ b/src/main/java/org/santalina/diving/service/BackupService.java
@@ -172,6 +172,7 @@ public class BackupService {
                 slot.club               = s.club();
                 slot.registrationOpen   = s.registrationOpen();
                 slot.registrationOpensAt = s.registrationOpensAt();
+                slot.requiresAttachments = s.requiresAttachments();
                 slot.createdAt          = s.createdAt() != null ? s.createdAt() : LocalDateTime.now();
                 slot.updatedAt          = LocalDateTime.now();
                 // Lier au créateur si possible
@@ -306,6 +307,11 @@ public class BackupService {
                 entry.medicalCertDate = we.medicalCertDate();
                 entry.licenseConfirmed = we.licenseConfirmed();
                 entry.club          = we.club();
+                entry.registrationStatus = we.registrationStatus() != null
+                        ? we.registrationStatus()
+                        : org.santalina.diving.domain.RegistrationStatus.PENDING_VERIFICATION;
+                entry.rejectionReason = we.rejectionReason();
+                // medicalCertPath / licenseQrPath non restaurés (fichiers absents après restore)
                 entry.persist();
                 waitingListCount++;
             }
@@ -341,7 +347,7 @@ public class BackupService {
         return new SlotEntry(s.id, s.slotDate, s.startTime, s.endTime,
                 s.diverCount, s.title, s.notes, s.slotType, s.club,
                 s.createdBy != null ? s.createdBy.id : null, s.createdAt,
-                s.registrationOpen, s.registrationOpensAt);
+                s.registrationOpen, s.registrationOpensAt, s.requiresAttachments);
     }
 
     private DiverEntry toDiverEntry(SlotDiver d) {
@@ -361,7 +367,9 @@ public class BackupService {
         return new WaitingListBackupEntry(e.id, e.slot != null ? e.slot.id : null,
                 e.firstName, e.lastName, e.email, e.level,
                 e.numberOfDives, e.lastDiveDate, e.preparedLevel, e.comment, e.registeredAt,
-                e.medicalCertDate, e.licenseConfirmed, e.club);
+                e.medicalCertDate, e.licenseConfirmed, e.club,
+                e.registrationStatus, e.rejectionReason);
+        // medicalCertPath / licenseQrPath exclus intentionnellement
     }
 }
 

--- a/src/main/java/org/santalina/diving/service/SlotService.java
+++ b/src/main/java/org/santalina/diving/service/SlotService.java
@@ -282,6 +282,7 @@ public class SlotService {
 
         slot.registrationOpen      = request.registrationOpen();
         slot.registrationOpensAt   = request.registrationOpensAt();
+        slot.requiresAttachments   = request.requiresAttachments();
         slot.persist();
 
         LOG.infof("Inscriptions libres %s (id=%d) par %s",

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,6 +4,7 @@ quarkus.http.port=8085
 
 # Diving site config
 app.diving.site-name=Carri\u00e8re de Saint-Lin
+app.diving.data-dir=./data
 
 # CORS
 quarkus.http.cors=true

--- a/src/main/resources/db/migration/V36__waiting_list_attachments.sql
+++ b/src/main/resources/db/migration/V36__waiting_list_attachments.sql
@@ -1,0 +1,6 @@
+-- Ajout du statut d'inscription et des chemins de pièces jointes sur waiting_list_entries
+ALTER TABLE waiting_list_entries ADD COLUMN registration_status VARCHAR(30) DEFAULT 'PENDING_VERIFICATION' NOT NULL;
+ALTER TABLE waiting_list_entries ADD COLUMN rejection_reason TEXT;
+ALTER TABLE waiting_list_entries ADD COLUMN medical_cert_path VARCHAR(500);
+ALTER TABLE waiting_list_entries ADD COLUMN license_qr_path VARCHAR(500);
+ALTER TABLE waiting_list_entries ADD COLUMN attachments_deleted_at TIMESTAMP;

--- a/src/main/resources/db/migration/V37__slot_requires_attachments.sql
+++ b/src/main/resources/db/migration/V37__slot_requires_attachments.sql
@@ -1,0 +1,2 @@
+-- Activation des pièces jointes obligatoires sur certains créneaux en inscription libre
+ALTER TABLE dive_slots ADD COLUMN requires_attachments BOOLEAN DEFAULT FALSE NOT NULL;

--- a/src/main/webui/src/App.css
+++ b/src/main/webui/src/App.css
@@ -543,16 +543,16 @@ body {
 }
 /* Case à cocher directeur */
 .diver-director-checkbox {
-  display: inline-flex; align-items: center; gap: 6px; font-size: 11px; white-space: nowrap;
+  display: inline-flex; align-items: flex-start; gap: 6px; font-size: 11px;
   color: #92400e; cursor: pointer; padding: 4px 8px;
   background: #fef9c3; border: 1px solid #fde68a; border-radius: 4px;
   line-height: 1.4; user-select: none;
 }
 .diver-director-checkbox input[type="checkbox"] {
-  cursor: pointer; margin: 0; flex-shrink: 0;
+  cursor: pointer; margin: 0; flex-shrink: 0; margin-top: 2px;
   width: 13px; height: 13px; accent-color: #d97706;
 }
-.diver-director-checkbox span { flex-shrink: 0; }
+.diver-director-checkbox span { flex-shrink: 1; }
 
 /* ========== SLOT FORM MODAL ========== */
 .slot-form-overlay {

--- a/src/main/webui/src/components/SelfRegistrationModal.tsx
+++ b/src/main/webui/src/components/SelfRegistrationModal.tsx
@@ -13,6 +13,17 @@ interface Props {
   config?: AppConfig;
 }
 
+const ALLOWED_EXTENSIONS = ['jpg', 'jpeg', 'png', 'pdf', 'webp'];
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 Mo
+
+function validateFile(file: File | null, label: string): string | null {
+  if (!file) return `Le fichier « ${label} » est obligatoire.`;
+  if (file.size > MAX_FILE_SIZE) return `« ${label} » dépasse 5 Mo.`;
+  const ext = file.name.split('.').pop()?.toLowerCase() ?? '';
+  if (!ALLOWED_EXTENSIONS.includes(ext)) return `« ${label} » doit être une image (JPG, PNG, WEBP) ou un PDF.`;
+  return null;
+}
+
 export function SelfRegistrationModal({ slot, onClose, onSuccess, config }: Props) {
   const storedUser = authService.getStoredUser();
   const isDP = storedUser?.role === 'DIVE_DIRECTOR';
@@ -31,8 +42,13 @@ export function SelfRegistrationModal({ slot, onClose, onSuccess, config }: Prop
   const [medicalCertDateText, setMedicalCertDateText] = useState('');
   const hiddenDateRef = useRef<HTMLInputElement>(null);
   const [licenseConfirmed, setLicenseConfirmed] = useState(false);
-  const [loading, setLoading]           = useState(false);
-  const [error, setError]               = useState<string | null>(null);
+
+  // Pièces jointes (uniquement si slot.requiresAttachments)
+  const [medicalCertFile, setMedicalCertFile] = useState<File | null>(null);
+  const [licenseQrFile,   setLicenseQrFile]   = useState<File | null>(null);
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError]     = useState<string | null>(null);
 
   const today = new Date().toISOString().split('T')[0];
 
@@ -79,12 +95,21 @@ export function SelfRegistrationModal({ slot, onClose, onSuccess, config }: Prop
       return;
     }
 
+    // Validation des pièces jointes si requises
+    if (slot.requiresAttachments) {
+      const certErr = validateFile(medicalCertFile, 'certificat médical');
+      if (certErr) { setError(certErr); return; }
+      const qrErr = validateFile(licenseQrFile, 'QR code de la licence');
+      if (qrErr) { setError(qrErr); return; }
+    }
+
     setLoading(true);
     try {
       if (emailChanged) {
         await authService.updateEmail(trimmedEmail);
       }
-      await waitingListService.register(slot.id, {
+
+      const req = {
         firstName: storedUser?.firstName ?? '',
         lastName:  storedUser?.lastName  ?? '',
         email:     trimmedEmail,
@@ -95,7 +120,14 @@ export function SelfRegistrationModal({ slot, onClose, onSuccess, config }: Prop
         medicalCertDate,
         licenseConfirmed,
         club: storedUser?.club || undefined,
-      });
+      };
+
+      if (slot.requiresAttachments && medicalCertFile && licenseQrFile) {
+        await waitingListService.registerWithAttachments(slot.id, req, medicalCertFile, licenseQrFile);
+      } else {
+        await waitingListService.register(slot.id, req);
+      }
+
       onSuccess(emailChanged ? trimmedEmail : undefined);
     } catch (err) {
       setError(getErrorMessage(err));
@@ -126,6 +158,16 @@ export function SelfRegistrationModal({ slot, onClose, onSuccess, config }: Prop
         }}>
           <div style={{ fontWeight: 600 }}>{userName}</div>
         </div>
+
+        {slot.requiresAttachments && (
+          <div style={{
+            background: '#eff6ff', border: '1px solid #bfdbfe', borderRadius: 8,
+            padding: '10px 14px', marginBottom: 14, fontSize: 13, color: '#1e40af',
+          }}>
+            📎 Ce créneau exige le dépôt de votre <strong>certificat médical</strong> et du
+            {' '}<strong>QR code de votre licence FFESSM</strong> (JPEG, PNG, PDF ou WEBP · 5 Mo max).
+          </div>
+        )}
 
         {error && (
           <div className="alert alert-error" style={{ marginBottom: 12 }}>{error}</div>
@@ -236,6 +278,49 @@ export function SelfRegistrationModal({ slot, onClose, onSuccess, config }: Prop
               </div>
             </div>
           </div>
+
+          {/* ── Pièces jointes ───────────────────────────────────────── */}
+          {slot.requiresAttachments && (
+            <>
+              <div className="form-group" style={{ marginTop: 12 }}>
+                <label>
+                  Certificat médical{' '}
+                  <span style={{ color: '#ef4444' }}>*</span>
+                  <span style={{ fontWeight: 'normal', color: '#6b7280' }}> (JPG, PNG, PDF, WEBP · 5 Mo)</span>
+                </label>
+                <input
+                  type="file"
+                  accept=".jpg,.jpeg,.png,.pdf,.webp,image/*,application/pdf"
+                  onChange={e => setMedicalCertFile(e.target.files?.[0] ?? null)}
+                  required
+                />
+                {medicalCertFile && (
+                  <span style={{ fontSize: 12, color: '#16a34a' }}>
+                    ✔ {medicalCertFile.name}
+                  </span>
+                )}
+              </div>
+
+              <div className="form-group" style={{ marginTop: 12 }}>
+                <label>
+                  QR code de la licence FFESSM{' '}
+                  <span style={{ color: '#ef4444' }}>*</span>
+                  <span style={{ fontWeight: 'normal', color: '#6b7280' }}> (JPG, PNG, PDF, WEBP · 5 Mo)</span>
+                </label>
+                <input
+                  type="file"
+                  accept=".jpg,.jpeg,.png,.pdf,.webp,image/*,application/pdf"
+                  onChange={e => setLicenseQrFile(e.target.files?.[0] ?? null)}
+                  required
+                />
+                {licenseQrFile && (
+                  <span style={{ fontSize: 12, color: '#16a34a' }}>
+                    ✔ {licenseQrFile.name}
+                  </span>
+                )}
+              </div>
+            </>
+          )}
 
           <div className="form-group" style={{ marginTop: 12 }}>
             <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', fontWeight: 'normal' }}>

--- a/src/main/webui/src/components/SlotBlock.tsx
+++ b/src/main/webui/src/components/SlotBlock.tsx
@@ -164,6 +164,7 @@ export function SlotBlock({
   const [regOpensAt, setRegOpensAt]     = useState(
     slot.registrationOpensAt ? slot.registrationOpensAt.slice(0, 16) : ''
   );
+  const [regRequiresAttachments, setRegRequiresAttachments] = useState(slot.requiresAttachments ?? false);
   const [regSaving, setRegSaving]       = useState(false);
   const [regError, setRegError]         = useState('');
   const [regSuccess, setRegSuccess]     = useState('');
@@ -491,6 +492,7 @@ export function SlotBlock({
       await waitingListService.updateRegistration(slot.id, {
         registrationOpen: regOpen,
         registrationOpensAt: regOpensAt ? regOpensAt + ':00' : null,
+        requiresAttachments: regRequiresAttachments,
       });
       setEditingReg(false);
       setRegSuccess(regOpen ? '✓ Inscriptions libres activées' : '✓ Inscriptions libres désactivées');
@@ -1038,6 +1040,7 @@ export function SlotBlock({
               onClick={() => {
                 setRegOpen(slot.registrationOpen);
                 setRegOpensAt(slot.registrationOpensAt ? slot.registrationOpensAt.slice(0, 16) : '');
+                setRegRequiresAttachments(slot.requiresAttachments ?? false);
                 setRegError('');
                 setEditingReg(true);
               }}
@@ -1064,6 +1067,16 @@ export function SlotBlock({
                     onChange={e => setRegOpensAt(e.target.value)}
                   />
                 </div>
+              )}
+              {regOpen && (
+                <label className="diver-director-checkbox" style={{ marginBottom: 8 }}>
+                  <input
+                    type="checkbox"
+                    checked={regRequiresAttachments}
+                    onChange={e => setRegRequiresAttachments(e.target.checked)}
+                  />
+                  <span>Exiger le certificat médical et le QR code de la licence</span>
+                </label>
               )}
               <div className="diver-form-actions" style={{ marginTop: 6 }}>
                 <button type="submit" disabled={regSaving} className="btn-diver-save">

--- a/src/main/webui/src/pages/HelpPage.tsx
+++ b/src/main/webui/src/pages/HelpPage.tsx
@@ -404,6 +404,25 @@ export function HelpPage() {
             <li>Cliquez sur <strong>M'inscrire sur la liste d'attente</strong>.</li>
             <li>Un <strong>e-mail de confirmation</strong> est envoyé à l'adresse renseignée.</li>
           </ol>
+
+          <h4>Créneau avec pièces jointes obligatoires</h4>
+          <p>
+            Certains créneaux exigent que le plongeur fournisse deux pièces jointes au moment de l'inscription :
+          </p>
+          <ul>
+            <li><strong>📄 Certificat médical</strong> — scan lisible du certificat médical en cours de validité.</li>
+            <li><strong>🪪 QR code de la licence FFESSM</strong> — capture d'écran ou photo du QR code disponible sur l'espace adhérent FFESSM.</li>
+          </ul>
+          <p>
+            Lorsque ces pièces jointes sont requises, deux champs d'envoi de fichier apparaissent en bas du formulaire d'inscription.
+            Formats acceptés : JPG, PNG, PDF, WebP — taille max. 5 Mo par fichier.
+          </p>
+          <div className="help-tip">
+            💡 Les pièces jointes sont vérifiées par le directeur de plongée avant validation de votre inscription.
+            Vous recevrez un e-mail selon le résultat de la vérification (dossier vérifié ✅ ou incomplet ⚠️).
+            En cas de dossier incomplet, votre inscription est <strong>annulée</strong> et vous serez invité(e) à vous réinscrire avec les documents corrects.
+          </div>
+
           <div className="help-tip">
             💡 Votre demande sera examinée par le directeur de plongée. Vous recevrez un e-mail de validation lorsqu'il aura accepté votre inscription.
           </div>
@@ -426,6 +445,10 @@ export function HelpPage() {
                 <li>Cochez <strong>Autoriser l'inscription libre des plongeurs</strong> pour ouvrir les inscriptions.</li>
                 <li>Renseignez optionnellement une <strong>date d'ouverture</strong> (les inscriptions ne seront acceptées qu'à partir de cette date/heure).</li>
                 <li>Sans date d'ouverture, les inscriptions sont actives immédiatement.</li>
+                <li>
+                  Cochez <strong>Exiger le certificat médical et le QR code de la licence</strong> pour obliger les plongeurs à joindre leurs pièces justificatives lors de l'inscription.
+                  Le directeur de plongée devra alors vérifier manuellement chaque dossier avant de valider l'inscription.
+                </li>
               </ul>
             </li>
             <li>Cliquez sur <strong>✓ Enregistrer</strong>.</li>
@@ -443,6 +466,25 @@ export function HelpPage() {
               Pour chaque entrée, vous voyez : nom, niveau, club d'appartenance (repris depuis le profil du plongeur), e-mail, nombre de plongées, date de la dernière plongée, niveau en préparation et commentaire éventuel.
             </li>
             <li>
+              Si des pièces jointes ont été fournies, des liens <strong>📄 Certificat médical</strong> et <strong>🪪 Licence FFESSM</strong> apparaissent.
+              Cliquez sur ces liens pour visualiser les documents dans un nouvel onglet.
+            </li>
+            <li>
+              Chaque dossier affiche un badge de statut :
+              <ul>
+                <li><strong>🕐 En attente de vérification</strong> — dossier soumis, non encore examiné.</li>
+                <li><strong>✅ Dossier vérifié</strong> — pièces jointes validées par le DP.</li>
+                <li><strong>⚠️ Dossier incomplet</strong> — le dossier a été rejeté ; l'inscription est supprimée et le plongeur est invité à se réinscrire avec les documents corrects.</li>
+              </ul>
+            </li>
+            <li>
+              Pour les créneaux avec pièces jointes obligatoires, utilisez les boutons :
+              <ul>
+                <li><strong>✅ Dossier OK</strong> — marque le dossier comme vérifié ; un e-mail de confirmation est envoyé au plongeur.</li>
+                <li><strong>⚠️ Incomplet</strong> — rejette le dossier ; vous pouvez saisir un motif optionnel (ex. : « Certificat illisible »). <strong>L'inscription est supprimée</strong> et les pièces jointes sont effacées. Un e-mail est envoyé au plongeur l'invitant à se réinscrire avec un dossier complet.</li>
+              </ul>
+            </li>
+            <li>
               Cliquez sur <strong>✓ Valider</strong> pour accepter la demande :
               le plongeur est transféré dans la liste des inscrits et reçoit un e-mail de confirmation après un délai de 15 minutes
               (pour laisser le temps au DP de réorganiser les palanquées avant que le plongeur soit notifié).
@@ -455,6 +497,9 @@ export function HelpPage() {
           </ol>
           <div className="help-tip">
             💡 Les plongeurs validés apparaissent dans la réserve <strong>Non assignés</strong> de la page d'organisation des palanquées.
+          </div>
+          <div className="help-tip">
+            💡 Les fichiers joints (certificat médical et QR code de licence) sont automatiquement supprimés 7 jours après la date du créneau pour des raisons de confidentialité.
           </div>
 
           <h4>Remettre un plongeur en liste d'attente</h4>

--- a/src/main/webui/src/pages/PalanqueePage.tsx
+++ b/src/main/webui/src/pages/PalanqueePage.tsx
@@ -9,7 +9,7 @@ import { slotMailService } from '../services/slotMailService';
 import { exportDiverListCsv } from '../utils/exportDiverList';
 import { RichTextEditor } from '../components/RichTextEditor';
 import { DpOrganizerMailer } from '../utils/dpMailDefaults';
-import type { DiveSlot, SlotDiver, Palanquee, WaitingListEntry } from '../types';
+import type { DiveSlot, SlotDiver, Palanquee, WaitingListEntry, RegistrationStatus } from '../types';
 
 // ── constantes ──────────────────────────────────────────────────────────────
 const LEVEL_COLORS: Record<string, string> = {
@@ -275,6 +275,11 @@ export function PalanqueePage({ slotId, onBack }: Props) {
   const [cancelingId, setCancelingId]     = useState<number | null>(null);
   const [wlError, setWlError]             = useState('');
   const [movingToWlId, setMovingToWlId]   = useState<number | null>(null);
+
+  // Mise à jour statut de vérification
+  const [statusUpdatingId, setStatusUpdatingId]           = useState<number | null>(null);
+  const [incompleteReasonId, setIncompleteReasonId]       = useState<number | null>(null);
+  const [incompleteReason, setIncompleteReason]           = useState('');
 
   // renaming state: palanqueeId → draft name
   const [renamingId, setRenamingId]     = useState<number | null>(null);
@@ -663,6 +668,50 @@ export function PalanqueePage({ slotId, onBack }: Props) {
     }
   }, [slotId]);
 
+  const openAttachment = useCallback(async (slotId: number, entryId: number, type: 'medical-cert' | 'license-qr') => {
+    const token = localStorage.getItem('token');
+    const url = waitingListService.getAttachmentUrl(slotId, entryId, type);
+    try {
+      const res = await fetch(url, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
+      if (!res.ok) {
+        alert('Impossible d\'ouvrir le fichier.');
+        return;
+      }
+      const blob = await res.blob();
+      const blobUrl = URL.createObjectURL(blob);
+      const win = window.open(blobUrl, '_blank');
+      // Libérer l'URL objet après que l'onglet l'a chargée
+      if (win) {
+        win.addEventListener('load', () => URL.revokeObjectURL(blobUrl), { once: true });
+      }
+    } catch {
+      alert('Erreur lors de l\'ouverture du fichier.');
+    }
+  }, []);
+
+  const handleUpdateStatus = useCallback(async (entryId: number, status: RegistrationStatus, reason?: string) => {
+    setStatusUpdatingId(entryId);
+    setWlError('');
+    try {
+      if (status === 'INCOMPLETE') {
+        await waitingListService.updateStatus(slotId, entryId, status, reason);
+        setWaitingList(prev => prev.filter(e => e.id !== entryId));
+      } else {
+        const updated = await waitingListService.updateStatus(slotId, entryId, status, reason);
+        setWaitingList(prev => prev.map(e => e.id === entryId ? updated : e));
+      }
+      setIncompleteReasonId(null);
+      setIncompleteReason('');
+    } catch (err: unknown) {
+      const m = (err as { response?: { data?: { message?: string } } })?.response?.data?.message;
+      setWlError(m || 'Erreur lors de la mise à jour du statut');
+    } finally {
+      setStatusUpdatingId(null);
+    }
+  }, [slotId]);
+
   const handleMoveToWaitingList = useCallback(async (diverId: number) => {
     if (!window.confirm('Remettre ce plongeur en liste d’attente ?')) return;
     setMovingToWlId(diverId);
@@ -890,6 +939,85 @@ export function PalanqueePage({ slotId, onBack }: Props) {
                         💬 <em>{entry.comment}</em>
                       </div>
                     )}
+
+                    {/* Statut de vérification */}
+                    <div style={{ display: 'flex', gap: 6, alignItems: 'center', marginTop: 6, flexWrap: 'wrap' }}>
+                      {entry.registrationStatus === 'VERIFIED' && (
+                        <span style={{ background: '#dcfce7', color: '#166534', borderRadius: 4, padding: '2px 8px', fontSize: 12, fontWeight: 600 }}>
+                          ✅ Dossier vérifié
+                        </span>
+                      )}
+                      {entry.registrationStatus === 'INCOMPLETE' && (
+                        <span style={{ background: '#fef3c7', color: '#92400e', borderRadius: 4, padding: '2px 8px', fontSize: 12, fontWeight: 600 }}>
+                          ⚠️ Dossier incomplet
+                        </span>
+                      )}
+                      {entry.registrationStatus === 'PENDING_VERIFICATION' && (
+                        <span style={{ background: '#e0f2fe', color: '#0369a1', borderRadius: 4, padding: '2px 8px', fontSize: 12 }}>
+                          🔍 Vérification en attente
+                        </span>
+                      )}
+                      {entry.rejectionReason && entry.registrationStatus === 'INCOMPLETE' && (
+                        <span style={{ color: '#92400e', fontSize: 12 }}>
+                          — {entry.rejectionReason}
+                        </span>
+                      )}
+                    </div>
+
+                    {/* Pièces jointes */}
+                    {(entry.hasMedicalCert || entry.hasLicenseQr) && (
+                      <div style={{ display: 'flex', gap: 8, marginTop: 6, flexWrap: 'wrap' }}>
+                        {entry.hasMedicalCert && (
+                          <button
+                            type="button"
+                            onClick={() => openAttachment(Number(slotId), entry.id, 'medical-cert')}
+                            style={{ fontSize: 12, color: '#1e40af', textDecoration: 'underline', background: 'none', border: 'none', padding: 0, cursor: 'pointer' }}
+                            title="Ouvrir le certificat médical"
+                          >
+                            📄 Certificat médical
+                          </button>
+                        )}
+                        {entry.hasLicenseQr && (
+                          <button
+                            type="button"
+                            onClick={() => openAttachment(Number(slotId), entry.id, 'license-qr')}
+                            style={{ fontSize: 12, color: '#1e40af', textDecoration: 'underline', background: 'none', border: 'none', padding: 0, cursor: 'pointer' }}
+                            title="Ouvrir le QR code de la licence"
+                          >
+                            🪪 Licence FFESSM
+                          </button>
+                        )}
+                      </div>
+                    )}
+
+                    {/* Formulaire motif incomplet */}
+                    {incompleteReasonId === entry.id && (
+                      <div style={{ marginTop: 8, display: 'flex', flexDirection: 'column', gap: 6 }}>
+                        <textarea
+                          value={incompleteReason}
+                          onChange={e => setIncompleteReason(e.target.value)}
+                          placeholder="Motif (ex : certificat médical illisible…)"
+                          rows={2}
+                          style={{ resize: 'vertical', fontSize: 13 }}
+                        />
+                        <div style={{ display: 'flex', gap: 6 }}>
+                          <button
+                            className="btn-wl-cancel"
+                            style={{ background: '#d97706', borderColor: '#d97706', color: '#fff' }}
+                            disabled={statusUpdatingId === entry.id}
+                            onClick={() => handleUpdateStatus(entry.id, 'INCOMPLETE', incompleteReason.trim() || undefined)}
+                          >
+                            {statusUpdatingId === entry.id ? '…' : '⚠️ Confirmer incomplet'}
+                          </button>
+                          <button
+                            className="btn-wl-cancel"
+                            onClick={() => { setIncompleteReasonId(null); setIncompleteReason(''); }}
+                          >
+                            Annuler
+                          </button>
+                        </div>
+                      </div>
+                    )}
                   </div>
 
                   <div className="palanquee-wl-entry-actions">
@@ -903,6 +1031,28 @@ export function PalanqueePage({ slotId, onBack }: Props) {
                     >
                       {approvingId === entry.id ? '…' : '✓ Valider'}
                     </button>
+                    {(entry.hasMedicalCert || entry.hasLicenseQr) && entry.registrationStatus !== 'VERIFIED' && (
+                      <button
+                        className="btn-wl-approve"
+                        style={{ background: '#16a34a', borderColor: '#16a34a' }}
+                        disabled={statusUpdatingId === entry.id}
+                        onClick={() => handleUpdateStatus(entry.id, 'VERIFIED')}
+                        title="Marquer le dossier comme vérifié et valide"
+                      >
+                        {statusUpdatingId === entry.id ? '…' : '✅ Dossier OK'}
+                      </button>
+                    )}
+                    {(entry.hasMedicalCert || entry.hasLicenseQr) && entry.registrationStatus !== 'INCOMPLETE' && (
+                      <button
+                        className="btn-wl-cancel"
+                        style={{ background: '#d97706', borderColor: '#d97706', color: '#fff' }}
+                        disabled={statusUpdatingId === entry.id}
+                        onClick={() => { setIncompleteReasonId(entry.id); setIncompleteReason(''); }}
+                        title="Marquer le dossier comme incomplet (avec motif)"
+                      >
+                        ⚠️ Incomplet
+                      </button>
+                    )}
                     <button
                       className="btn-wl-cancel"
                       disabled={cancelingId === entry.id}

--- a/src/main/webui/src/services/waitingListService.ts
+++ b/src/main/webui/src/services/waitingListService.ts
@@ -1,11 +1,27 @@
 import api from './api';
-import type { WaitingListEntry, WaitingListRequest, UpdateRegistrationRequest } from '../types';
+import type { WaitingListEntry, WaitingListRequest, UpdateRegistrationRequest, RegistrationStatus } from '../types';
 import type { DiveSlot } from '../types';
 
 export const waitingListService = {
-  /** Inscription d'un plongeur en liste d'attente. */
+  /** Inscription JSON simple (créneau sans pièces jointes obligatoires). */
   register: (slotId: number, req: WaitingListRequest): Promise<WaitingListEntry> =>
     api.post(`/slots/${slotId}/waiting-list`, req).then(r => r.data),
+
+  /** Inscription multipart avec pièces jointes (certificat médical + QR code). */
+  registerWithAttachments: (
+    slotId: number,
+    req: WaitingListRequest,
+    medicalCert: File,
+    licenseQr: File,
+  ): Promise<WaitingListEntry> => {
+    const form = new FormData();
+    form.append('data', JSON.stringify(req));
+    form.append('medicalCert', medicalCert);
+    form.append('licenseQr', licenseQr);
+    return api.post(`/slots/${slotId}/waiting-list/with-attachments`, form, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    }).then(r => r.data);
+  },
 
   /** Lecture de la liste d'attente (DP / ADMIN seulement). */
   getWaitingList: (slotId: number): Promise<WaitingListEntry[]> =>
@@ -14,6 +30,15 @@ export const waitingListService = {
   /** Valider une entrée → la transfère dans slot_divers. */
   approve: (slotId: number, entryId: number): Promise<void> =>
     api.post(`/slots/${slotId}/waiting-list/${entryId}/approve`).then(r => r.data),
+
+  /** Mettre à jour le statut de vérification d'un dossier (DP / ADMIN). */
+  updateStatus: (
+    slotId: number,
+    entryId: number,
+    status: RegistrationStatus,
+    reason?: string,
+  ): Promise<WaitingListEntry> =>
+    api.patch(`/slots/${slotId}/waiting-list/${entryId}/status`, { status, reason }).then(r => r.data),
 
   /** Récupère l'entrée en liste d'attente de l'utilisateur connecté pour ce créneau (null si absent). */
   getMyEntry: (slotId: number): Promise<WaitingListEntry | null> =>
@@ -28,4 +53,8 @@ export const waitingListService = {
   /** Modifier les paramètres d'inscription libre du créneau (DP / ADMIN). */
   updateRegistration: (slotId: number, req: UpdateRegistrationRequest): Promise<DiveSlot> =>
     api.patch(`/slots/${slotId}/registration`, req).then(r => r.data),
+
+  /** Construit l'URL de téléchargement d'une pièce jointe (nécessite le token dans le header de l'API). */
+  getAttachmentUrl: (slotId: number, entryId: number, type: 'medical-cert' | 'license-qr'): string =>
+    `/api/attachments/${slotId}/${entryId}/${type}`,
 };

--- a/src/main/webui/src/types/index.ts
+++ b/src/main/webui/src/types/index.ts
@@ -110,6 +110,7 @@ export interface DiveSlot {
   registrationOpen: boolean;
   registrationOpensAt: string | null; // ISO datetime or null
   waitingListCount?: number;
+  requiresAttachments: boolean;
 }
 
 export interface SlotRequest {
@@ -290,6 +291,8 @@ export const PREPARED_LEVELS = [
   'PA20','PA40','PA60','PN','PNC','PB1','PB2','PV1','PV2'
 ] as const;
 
+export type RegistrationStatus = 'PENDING_VERIFICATION' | 'VERIFIED' | 'INCOMPLETE';
+
 export interface WaitingListEntry {
   id: number;
   slotId: number;
@@ -305,6 +308,10 @@ export interface WaitingListEntry {
   medicalCertDate?: string;  // YYYY-MM-DD
   licenseConfirmed?: boolean;
   club?: string;
+  registrationStatus: RegistrationStatus;
+  rejectionReason?: string | null;
+  hasMedicalCert: boolean;
+  hasLicenseQr: boolean;
 }
 
 export interface WaitingListRequest {
@@ -325,4 +332,5 @@ export interface WaitingListRequest {
 export interface UpdateRegistrationRequest {
   registrationOpen: boolean;
   registrationOpensAt?: string | null; // ISO datetime or null
+  requiresAttachments: boolean;
 }

--- a/src/test/java/org/santalina/diving/integration/WaitingListResourceIT.java
+++ b/src/test/java/org/santalina/diving/integration/WaitingListResourceIT.java
@@ -400,6 +400,217 @@ class WaitingListResourceIT {
         }
     }
 
+    // ── Tests statut (PATCH /{entryId}/status) ────────────────────────────────
+
+    @Test
+    @TestSecurity(user = "admin@test.com", roles = {"ADMIN"})
+    void updateStatus_shouldReturn200_whenVerified() {
+        DiveSlot slot = createSlot(true);
+        try {
+            WaitingListEntry entry = createEntry(slot.id);
+
+            given()
+                .contentType(ContentType.JSON)
+                .body("{\"status\":\"VERIFIED\"}")
+                .when().patch("/api/slots/{slotId}/waiting-list/{entryId}/status",
+                        slot.id, entry.id)
+                .then()
+                .statusCode(200)
+                .body("registrationStatus", equalTo("VERIFIED"));
+        } finally {
+            cleanup(slot.id);
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "admin@test.com", roles = {"ADMIN"})
+    void updateStatus_shouldReturn204_whenIncomplete_andDeleteEntry() {
+        DiveSlot slot = createSlot(true);
+        try {
+            WaitingListEntry entry = createEntry(slot.id);
+
+            given()
+                .contentType(ContentType.JSON)
+                .body("{\"status\":\"INCOMPLETE\",\"reason\":\"Certificat illisible\"}")
+                .when().patch("/api/slots/{slotId}/waiting-list/{entryId}/status",
+                        slot.id, entry.id)
+                .then()
+                .statusCode(204);
+
+            // Vérifier que l'entrée a été supprimée
+            given()
+                .when().get("/api/slots/{slotId}/waiting-list", slot.id)
+                .then()
+                .statusCode(200)
+                .body("size()", equalTo(0));
+        } finally {
+            cleanup(slot.id);
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "unknown_diver@test.com", roles = {"DIVER"})
+    void updateStatus_shouldReturn403_forDiver() {
+        DiveSlot slot = createSlot(true);
+        try {
+            WaitingListEntry entry = createEntry(slot.id);
+
+            given()
+                .contentType(ContentType.JSON)
+                .body("{\"status\":\"VERIFIED\"}")
+                .when().patch("/api/slots/{slotId}/waiting-list/{entryId}/status",
+                        slot.id, entry.id)
+                .then()
+                .statusCode(403);
+        } finally {
+            cleanup(slot.id);
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "admin@test.com", roles = {"ADMIN"})
+    void updateStatus_shouldReturn400_whenStatusInvalid() {
+        DiveSlot slot = createSlot(true);
+        try {
+            WaitingListEntry entry = createEntry(slot.id);
+
+            given()
+                .contentType(ContentType.JSON)
+                .body("{\"status\":\"INVALID_STATUS\"}")
+                .when().patch("/api/slots/{slotId}/waiting-list/{entryId}/status",
+                        slot.id, entry.id)
+                .then()
+                .statusCode(400);
+        } finally {
+            cleanup(slot.id);
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "admin@test.com", roles = {"ADMIN"})
+    void updateStatus_shouldReturn404_whenEntryNotFound() {
+        DiveSlot slot = createSlot(true);
+        try {
+            given()
+                .contentType(ContentType.JSON)
+                .body("{\"status\":\"VERIFIED\"}")
+                .when().patch("/api/slots/{slotId}/waiting-list/999999/status", slot.id)
+                .then()
+                .statusCode(404);
+        } finally {
+            cleanup(slot.id);
+        }
+    }
+
+    // ── Tests pièces jointes dans la réponse ──────────────────────────────────
+
+    @Test
+    @TestSecurity(user = "admin@test.com", roles = {"ADMIN"})
+    void getWaitingList_shouldIncludeRegistrationStatusField() {
+        DiveSlot slot = createSlot(true);
+        try {
+            createEntry(slot.id);
+
+            given()
+                .when().get("/api/slots/{slotId}/waiting-list", slot.id)
+                .then()
+                .statusCode(200)
+                .body("[0].registrationStatus", equalTo("PENDING_VERIFICATION"))
+                .body("[0].hasMedicalCert", equalTo(false))
+                .body("[0].hasLicenseQr", equalTo(false));
+        } finally {
+            cleanup(slot.id);
+        }
+    }
+
+    // ── Tests inscription avec pièces jointes requises (validation backend) ───
+
+    @Test
+    @TestSecurity(user = "diver@test.com", roles = {"DIVER"})
+    void register_shouldReturn201_whenSlotRequiresAttachments_andFilesProvided() {
+        DiveSlot slot = createSlotWithAttachments();
+        try {
+            byte[] smallPng = new byte[]{(byte)0x89,'P','N','G',0x0D,0x0A,0x1A,0x0A};
+
+            given()
+                .contentType("multipart/form-data")
+                .multiPart("data", """
+                    {"firstName":"Bob","lastName":"DUPONT",
+                     "email":"bob_att@test.com","emailConfirm":"bob_att@test.com",
+                     "level":"N2","numberOfDives":10,
+                     "lastDiveDate":"2025-03-15",
+                     "medicalCertDate":"2099-07-01",
+                     "licenseConfirmed":true}
+                    """, "application/json")
+                .multiPart("medicalCert", "cert.png", smallPng, "image/png")
+                .multiPart("licenseQr",   "qr.png",   smallPng, "image/png")
+                .when().post("/api/slots/{slotId}/waiting-list/with-attachments", slot.id)
+                .then()
+                .statusCode(201)
+                .body("email", equalTo("bob_att@test.com"))
+                .body("hasMedicalCert", equalTo(true))
+                .body("hasLicenseQr", equalTo(true));
+        } finally {
+            cleanup(slot.id);
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "diver@test.com", roles = {"DIVER"})
+    void register_shouldReturn400_whenSlotRequiresAttachments_butUsesJsonEndpoint() {
+        DiveSlot slot = createSlotWithAttachments();
+        try {
+            given()
+                .contentType(ContentType.JSON)
+                .body("""
+                    {"firstName":"Bob","lastName":"DUPONT",
+                     "email":"bob_no_att@test.com","emailConfirm":"bob_no_att@test.com",
+                     "level":"N2","numberOfDives":10,
+                     "lastDiveDate":"2025-03-15",
+                     "medicalCertDate":"2099-07-01",
+                     "licenseConfirmed":true}
+                    """)
+                .when().post("/api/slots/{slotId}/waiting-list", slot.id)
+                .then()
+                .statusCode(400);
+        } finally {
+            cleanup(slot.id);
+        }
+    }
+
+    @Transactional
+    DiveSlot createSlotWithAttachments() {
+        User creator = new User();
+        creator.email        = "dp_att_test_" + System.nanoTime() + "@test.com";
+        creator.firstName    = "DP";
+        creator.lastName     = "ATT";
+        creator.passwordHash = "x";
+        creator.role         = UserRole.DIVE_DIRECTOR;
+        creator.roles        = java.util.Set.of(UserRole.DIVE_DIRECTOR);
+        creator.persist();
+
+        DiveSlot slot = new DiveSlot();
+        slot.slotDate              = LocalDate.of(2099, 8, 15);
+        slot.startTime             = LocalTime.of(9, 0);
+        slot.endTime               = LocalTime.of(12, 0);
+        slot.diverCount            = 8;
+        slot.createdBy             = creator;
+        slot.registrationOpen      = true;
+        slot.requiresAttachments   = true;
+        slot.persist();
+
+        SlotDiver dp = new SlotDiver();
+        dp.slot       = slot;
+        dp.firstName  = "DP";
+        dp.lastName   = "ATT";
+        dp.level      = "MF1";
+        dp.email      = creator.email;
+        dp.isDirector = true;
+        dp.persist();
+
+        return slot;
+    }
+
     @Transactional
     WaitingListEntry createEntryWithClub(Long slotId, String club) {
         DiveSlot slot = DiveSlot.findById(slotId);

--- a/src/test/java/org/santalina/diving/unit/WaitingListMailerTest.java
+++ b/src/test/java/org/santalina/diving/unit/WaitingListMailerTest.java
@@ -167,4 +167,78 @@ class WaitingListMailerTest {
                 .anyMatch(v -> v.contains(BASE_URL + "/?goto=profile")),
                 "Le header List-Unsubscribe du mail DP doit pointer vers /profile");
     }
+
+    // ── sendRegistrationIncomplete ───────────────────────────────────────────
+
+    @Test
+    void sendRegistrationIncomplete_htmlShouldContainDoctype() {
+        mailer.sendRegistrationIncomplete(buildEntry(), buildSlot(), "Certificat illisible");
+
+        String html = mailbox.getMailsSentTo(DIVER_EMAIL).get(0).getHtml();
+        assertTrue(html.contains("<!DOCTYPE html>"), "Le mail doit contenir <!DOCTYPE html>");
+    }
+
+    @Test
+    void sendRegistrationIncomplete_shouldContainReason() {
+        mailer.sendRegistrationIncomplete(buildEntry(), buildSlot(), "Photo floue");
+
+        String html = mailbox.getMailsSentTo(DIVER_EMAIL).get(0).getHtml();
+        assertTrue(html.contains("Photo floue"), "Le motif de rejet doit figurer dans le mail");
+    }
+
+    @Test
+    void sendRegistrationIncomplete_shouldWorkWithoutReason() {
+        mailer.sendRegistrationIncomplete(buildEntry(), buildSlot(), null);
+
+        assertFalse(mailbox.getMailsSentTo(DIVER_EMAIL).isEmpty(),
+                "Un mail doit être envoyé même sans motif");
+    }
+
+    @Test
+    void sendRegistrationIncomplete_shouldContainListUnsubscribeHeader() {
+        mailer.sendRegistrationIncomplete(buildEntry(), buildSlot(), null);
+
+        var mail = mailbox.getMailsSentTo(DIVER_EMAIL).get(0);
+        assertTrue(mail.getHeaders().get("List-Unsubscribe").stream()
+                .anyMatch(v -> v.contains(BASE_URL + "/?goto=profile")),
+                "Le header List-Unsubscribe doit pointer vers /profile");
+    }
+
+    @Test
+    void sendRegistrationIncomplete_shouldNotSendWhenGlobalDisabled() {
+        when(configService.isNotifRegistrationEnabled()).thenReturn(false);
+        mailer.sendRegistrationIncomplete(buildEntry(), buildSlot(), "test");
+
+        assertTrue(mailbox.getMailsSentTo(DIVER_EMAIL).isEmpty(),
+                "Aucun mail ne doit être envoyé si la notification globale est désactivée");
+    }
+
+    // ── sendRegistrationVerified ─────────────────────────────────────────────
+
+    @Test
+    void sendRegistrationVerified_htmlShouldContainDoctype() {
+        mailer.sendRegistrationVerified(buildEntry(), buildSlot());
+
+        String html = mailbox.getMailsSentTo(DIVER_EMAIL).get(0).getHtml();
+        assertTrue(html.contains("<!DOCTYPE html>"), "Le mail doit contenir <!DOCTYPE html>");
+    }
+
+    @Test
+    void sendRegistrationVerified_shouldContainListUnsubscribeHeader() {
+        mailer.sendRegistrationVerified(buildEntry(), buildSlot());
+
+        var mail = mailbox.getMailsSentTo(DIVER_EMAIL).get(0);
+        assertTrue(mail.getHeaders().get("List-Unsubscribe").stream()
+                .anyMatch(v -> v.contains(BASE_URL + "/?goto=profile")),
+                "Le header List-Unsubscribe doit pointer vers /profile");
+    }
+
+    @Test
+    void sendRegistrationVerified_shouldNotSendWhenGlobalDisabled() {
+        when(configService.isNotifRegistrationEnabled()).thenReturn(false);
+        mailer.sendRegistrationVerified(buildEntry(), buildSlot());
+
+        assertTrue(mailbox.getMailsSentTo(DIVER_EMAIL).isEmpty(),
+                "Aucun mail ne doit être envoyé si la notification globale est désactivée");
+    }
 }


### PR DESCRIPTION
Lorsque le DP marque un dossier comme incomplet :
- les pièces jointes sont supprimées du disque
- l'inscription est supprimée (le plongeur doit se réinscrire)
- le backend retourne 204 No Content au lieu de 200
- l'e-mail invite désormais le plongeur à se réinscrire avec un dossier complet, plutôt que de contacter le DP

Côté frontend, l'entrée est retirée de la liste d'attente à la réception du 204 (filter au lieu de map).

Tests : updateStatus_shouldReturn204_whenIncomplete_andDeleteEntry vérifie le 204 et la disparition de l'entrée.

Aide en ligne mise à jour (badge, bouton DP, tip plongeur).